### PR TITLE
[#100412960] Terrraform deployment for MicroBOSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+gce/ssh/
+aws/ssh/
+gce/account.json
+*.tfstate
+*.tfstate.backup

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: all apply provision destroy ssh
+
+all:
+	$(error Usage: make <aws|gce> DEPLOY_ENV=name)
+
+check-env-vars:
+ifndef DEPLOY_ENV
+    $(error Must pass DEPLOY_ENV=<name>)
+endif
+
+set-aws:
+	$(eval dir=aws)
+set-gce:
+	$(eval dir=gce)
+
+aws: set-aws apply provision
+gce: set-gce apply provision
+
+apply-aws: set-aws apply
+apply-gce: set-gce apply
+apply: check-env-vars
+	@cd ${dir} && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV}
+
+provision-aws: set-aws provision
+provision-gce: set-gce provision
+provision: check-env-vars
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash provision.sh'
+
+bosh-delete-aws: set-aws bosh-delete
+bosh-delete-gce: set-gce bosh-delete
+bosh-delete:
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) './`ls bosh-init-*` delete manifest_${dir}.yml'
+
+destroy-aws: set-aws destroy
+destroy-gce: set-gce destroy
+destroy:
+	@cd ${dir} && terraform destroy -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV}
+
+show-aws: set-aws show
+show-gce: set-gce show
+show:
+	@cd ${dir} && terraform show ${DEPLOY_ENV}.tfstate
+
+ssh-aws: set-aws ssh
+ssh-gce: set-gce ssh
+ssh: check-env-vars
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Make commands have been created for this:
 The bosh VM creation is currently flaky on GCE. It hangs waiting for ssh to start listening at step:
 
 ```
-Waiting for the agent on VM 'vm-10ced236-8fd0-4274-4f51-3b2ffdc53c7a' to be ready... 
+Waiting for the agent on VM 'vm-10ced236-8fd0-4274-4f51-3b2ffdc53c7a' to be ready...
 ```
-The workaround is to reset the VM via the GCE console, and the deployment should continue.
+
+One quick workaround is to reset the VM via the GCE console while is waiting,
+and the deployment should continue after one seconds. You can restart the VM
+with the following `gcloud` command:
+
+```
+gcloud compute instances reset --zone europe-west1-b vm-10ced236-8fd0-4274-4f51-3b2ffdc53c7a
+```
+
+Otherwise, letting it timeout and reruning the `make` command, it will rerun the `bosh-init` which
+will delete the old VM and create a new one. Repeat this step until one works :)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,56 @@
-# CloudFoundry Terraform
+#CloudFoundry Terraform
 
 To provision a microbosh instance on AWS and GCE.
+
+In order to deploy a microbosh, it is necessary to first create subnets, security groups and static IP reservations which will be used by bosh-init when deploying the microbosh. We are using terraform to create these resources, along with a bastion host which will perform the actual `bosh-init` steps to create the microbosh.
+
+##Pre-requisites
+* You will need to be running ssh-agent and have performed an `ssh-add <deployer_key>` to make the credentials available for ssh to be able to connect into the bastion host
+* Make available the ssh directory inside aws and gce
+
+```
+aws/
+    ssh/
+        insecure-deployer
+        insecure-deployer.pub
+gce/
+    ssh/
+        insecure-deployer
+        insecure-deployer.pub
+```
+* Provide `account.json` inside gce
+* Provide AWS access keys as environment variables, plus the corresponding terraform variables. Example in profile:
+
+```
+export AWS_ACCESS_KEY_ID=XXXXXXXXXX
+export AWS_SECRET_ACCESS_KEY=YYYYYYYYYY
+export TF_VAR_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+export TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+```
+
+##Usage
+```
+make gce DEPLOY_ENV=<environment_name>
+```
+or...
+
+```
+make aws DEPLOY_ENV=<environment_name>
+```
+See the Makefile for other options.
+
+Please note that although we're using `terraform apply` to create the resources, a corresponding `terraform destroy` operation will be unaware of the microbosh VM that bosh-init creates for us. Before 'terraform destroy' can complete, it will be necessary to ssh into the bastion machine and run './bosh-init delete manifest.yml' - this will trigger bosh-init to delete it's deployment, after which 'terraform destroy' can clean up the rest.
+
+Make commands have been created for this:
+
+* `bosh-delete-aws` / `bosh-delete-gce`
+* `destroy-aws` / `destroy-gce`
+
+**Known issue**
+
+The bosh VM creation is currently flaky on GCE. It hangs waiting for ssh to start listening at step:
+
+```
+Waiting for the agent on VM 'vm-10ced236-8fd0-4274-4f51-3b2ffdc53c7a' to be ready... 
+```
+The workaround is to reset the VM via the GCE console, and the deployment should continue.

--- a/aws/aws-vpc.tf
+++ b/aws/aws-vpc.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region      = "${var.region}"
+}
+
+resource "aws_vpc" "default" {
+  cidr_block = "${var.vpc_cidr}"
+  enable_dns_hostnames = true
+  tags {
+    Name = "${var.env}-tsuru"
+  }
+}

--- a/aws/aws-vpc.tf
+++ b/aws/aws-vpc.tf
@@ -6,6 +6,6 @@ resource "aws_vpc" "default" {
   cidr_block = "${var.vpc_cidr}"
   enable_dns_hostnames = true
   tags {
-    Name = "${var.env}-tsuru"
+    Name = "${var.env}-cf"
   }
 }

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -35,7 +35,7 @@ resource "aws_instance" "bastion" {
   }
 
   provisioner "remote-exec" {
-        inline = ["cat << EOF > /home/ubuntu/manifest.yml",
+        inline = ["cat << EOF > /home/ubuntu/manifest_aws.yml",
          "${template_file.manifest.rendered}",
          "EOF"]
   }

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -54,12 +54,5 @@ resource "aws_instance" "bastion" {
       source = "${path.module}/provision.sh"
       destination = "/home/ubuntu/provision.sh"
   }
-
-  provisioner "remote-exec" {
-      inline = [
-          "chmod +x /home/ubuntu/provision.sh",
-          "/home/ubuntu/provision.sh",
-      ]
-  }
 }
 

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -14,6 +14,8 @@ resource "template_file" "manifest" {
         aws_availability_zone = "${var.zones.zone0}"
         aws_secret_access_key = "${var.AWS_SECRET_ACCESS_KEY}"
         aws_access_key_id = "${var.AWS_ACCESS_KEY_ID}"
+        aws_region       = "${var.region}"
+        bosh_security_group = "${var.env}-cf-microbosh"
     }
 }
 

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -53,7 +53,7 @@ resource "aws_instance" "bastion" {
       source = "${path.module}/provision.sh"
       destination = "/home/ubuntu/provision.sh"
   }
-
+  
   provisioner "remote-exec" {
       inline = [
           "chmod +x /home/ubuntu/provision.sh",

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -23,7 +23,6 @@ resource "aws_instance" "bastion" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.bastion.0.id}"
-  associate_public_ip_address = true
   security_groups = ["${aws_security_group.bastion.id}"]
   key_name = "${var.key_pair_name}"
   source_dest_check = false
@@ -55,7 +54,7 @@ resource "aws_instance" "bastion" {
       source = "${path.module}/provision.sh"
       destination = "/home/ubuntu/provision.sh"
   }
-  
+
   provisioner "remote-exec" {
       inline = [
           "chmod +x /home/ubuntu/provision.sh",

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -1,0 +1,64 @@
+# Terraform currently only has limited support for reading environment variables
+# Variables for use with terraform must be prefexed with 'TF_VAR_'
+# These two variables are passed in as environment variables named:
+# TF_VAR_AWS_ACCESS_KEY_ID and TF_VAR_AWS_SECRET_ACCESS_KEY respectively
+variable "AWS_ACCESS_KEY_ID" {}
+variable "AWS_SECRET_ACCESS_KEY" {}
+
+resource "template_file" "manifest" {
+    filename = "${path.module}/manifest.yml.tpl"
+
+    vars {
+        aws_static_ip    =  "${aws_eip.bosh.public_ip}"
+        aws_subnet_id    =  "${aws_subnet.bastion.0.id}"
+        aws_availability_zone = "${var.zones.zone0}"
+        aws_secret_access_key = "${var.AWS_SECRET_ACCESS_KEY}"
+        aws_access_key_id = "${var.AWS_ACCESS_KEY_ID}"
+    }
+}
+
+resource "aws_instance" "bastion" {
+  ami = "${lookup(var.amis, var.region)}"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.bastion.0.id}"
+  associate_public_ip_address = true
+  security_groups = ["${aws_security_group.bastion.id}"]
+  key_name = "${var.key_pair_name}"
+  source_dest_check = false
+  tags = {
+    Name = "${var.env}-bastion"
+  }
+  connection {
+    user = "ubuntu"
+    key_file = "ssh/insecure-deployer"
+  }
+
+  provisioner "remote-exec" {
+        inline = ["cat << EOF > /home/ubuntu/manifest.yml",
+         "${template_file.manifest.rendered}",
+         "EOF"]
+  }
+
+  provisioner "file" {
+          source = "${path.module}/ssh/insecure-deployer"
+          destination = "/home/ubuntu/.ssh/id_rsa"
+  }
+
+  provisioner "file" {
+          source = "${path.module}/ssh/insecure-deployer.pub"
+          destination = "/home/ubuntu/.ssh/id_rsa.pub"
+  }
+
+  provisioner "file" {
+      source = "${path.module}/provision.sh"
+      destination = "/home/ubuntu/provision.sh"
+  }
+
+  provisioner "remote-exec" {
+      inline = [
+          "chmod +x /home/ubuntu/provision.sh",
+          "/home/ubuntu/provision.sh",
+      ]
+  }
+}
+

--- a/aws/firewall.tf
+++ b/aws/firewall.tf
@@ -71,7 +71,7 @@ resource "aws_security_group" "bosh-ports" {
   }
 
   tags {
-    Name = "${var.env}-bastion"
+    Name = "${var.env}-cf-microbosh"
   }
 
 }

--- a/aws/firewall.tf
+++ b/aws/firewall.tf
@@ -38,36 +38,42 @@ resource "aws_security_group" "bosh-ports" {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
   }
 
   ingress {
     from_port = 4222
     to_port   = 4222
     protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
   }
 
   ingress {
     from_port = 6868
     to_port   = 6868
     protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
   }
 
   ingress {
     from_port = 25250
     to_port   = 25250
     protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
   }
 
   ingress {
     from_port = 25555
     to_port   = 25555
     protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
   }
 
   ingress {
     from_port = 25777
     to_port   = 25777
     protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
   }
 
   tags {

--- a/aws/firewall.tf
+++ b/aws/firewall.tf
@@ -1,0 +1,79 @@
+resource "aws_security_group" "bastion" {
+  name = "${var.env}-bastion"
+  description = "Security group for bastion that allows SSH traffic from the office"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
+  }
+
+  tags {
+    Name = "${var.env}-bastion"
+  }
+}
+
+resource "aws_security_group" "bosh-ports" {
+  name = "${var.env}-cf-microbosh"
+  description = "SSH and Bosh ports from trusted external sources"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+  }
+
+  ingress {
+    from_port = 4222
+    to_port   = 4222
+    protocol  = "tcp"
+  }
+
+  ingress {
+    from_port = 6868
+    to_port   = 6868
+    protocol  = "tcp"
+  }
+
+  ingress {
+    from_port = 25250
+    to_port   = 25250
+    protocol  = "tcp"
+  }
+
+  ingress {
+    from_port = 25555
+    to_port   = 25555
+    protocol  = "tcp"
+  }
+
+  ingress {
+    from_port = 25777
+    to_port   = 25777
+    protocol  = "tcp"
+  }
+
+  tags {
+    Name = "${var.env}-bastion"
+  }
+
+}
+
+

--- a/aws/globals.tf
+++ b/aws/globals.tf
@@ -1,0 +1,1 @@
+../globals.tf

--- a/aws/manifest.yml.tpl
+++ b/aws/manifest.yml.tpl
@@ -1,0 +1,135 @@
+---
+name: bosh
+
+releases:
+- name: bosh
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=195
+  sha1: 28bb0d540b8069e4271baba6ad75c9d4e2bf8752
+- name: bosh-aws-cpi
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=28
+  sha1: c7ce03393ebedd87a860dc609758ddb9654360fa
+
+resource_pools:
+- name: vms
+  network: private
+  stemcell:
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3012
+    sha1: 3380b55948abe4c437dee97f67d2d8df4eec3fc1
+  cloud_properties:
+    instance_type: m3.xlarge
+    ephemeral_disk: {size: 25_000, type: gp2}
+    availability_zone: ${aws_availability_zone} # <--- Replace with Availability Zone
+
+disk_pools:
+- name: disks
+  disk_size: 20_000
+  cloud_properties: {type: gp2}
+
+networks:
+- name: private
+  type: manual
+  subnets:
+  - range: 10.0.0.0/24
+    gateway: 10.0.0.1
+    dns: [10.0.0.2]
+    cloud_properties: {subnet: ${aws_subnet_id}} # <--- Replace with Subnet ID
+- name: public
+  type: vip
+
+jobs:
+- name: bosh
+  instances: 1
+
+  templates:
+  - {name: nats, release: bosh}
+  - {name: redis, release: bosh}
+  - {name: postgres, release: bosh}
+  - {name: blobstore, release: bosh}
+  - {name: director, release: bosh}
+  - {name: health_monitor, release: bosh}
+  - {name: registry, release: bosh}
+  - {name: cpi, release: bosh-aws-cpi}
+
+  resource_pool: vms
+  persistent_disk_pool: disks
+
+  networks:
+  - name: private
+    static_ips: [10.0.0.6]
+    default: [dns, gateway]
+  - name: public
+    static_ips: [${aws_static_ip}] # <--- Replace with Elastic IP
+
+  properties:
+    nats:
+      address: 127.0.0.1
+      user: nats
+      password: nats-password
+
+    redis:
+      listen_addresss: 127.0.0.1
+      address: 127.0.0.1
+      password: redis-password
+
+    postgres: &db
+      host: 127.0.0.1
+      user: postgres
+      password: postgres-password
+      database: bosh
+      adapter: postgres
+
+    registry:
+      address: 10.0.0.6
+      host: 10.0.0.6
+      db: *db
+      http: {user: admin, password: admin, port: 25777}
+      username: admin
+      password: admin
+      port: 25777
+
+    blobstore:
+      address: 10.0.0.6
+      port: 25250
+      provider: dav
+      director: {user: director, password: director-password}
+      agent: {user: agent, password: agent-password}
+
+    director:
+      address: 127.0.0.1
+      name: my-bosh
+      db: *db
+      cpi_job: cpi
+      max_threads: 10
+
+    hm:
+      director_account: {user: admin, password: admin}
+      resurrector_enabled: true
+
+    aws: &aws
+      access_key_id: ${aws_access_key_id} # <--- Replace with AWS Access Key ID
+      secret_access_key: ${aws_secret_access_key} # <--- Replace with AWS Secret Key
+      default_key_name: bosh
+      default_security_groups: [bosh]
+      region: us-east-1
+
+    agent: {mbus: "nats://nats:nats-password@10.0.0.6:4222"}
+
+    ntp: &ntp [0.pool.ntp.org, 1.pool.ntp.org]
+
+cloud_provider:
+  template: {name: cpi, release: bosh-aws-cpi}
+
+  ssh_tunnel:
+    host: ${aws_static_ip} # <--- Replace with your Elastic IP address
+    port: 22
+    user: vcap
+    private_key: ./bosh.pem # Path relative to this manifest file
+
+  mbus: "https://mbus:mbus-password@${aws_static_ip}:6868" # <--- Replace with Elastic IP
+
+  properties:
+    aws: *aws
+    agent: {mbus: "https://mbus:mbus-password@0.0.0.0:6868"}
+    blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
+    ntp: *ntp
+

--- a/aws/manifest.yml.tpl
+++ b/aws/manifest.yml.tpl
@@ -3,8 +3,8 @@ name: bosh
 
 releases:
 - name: bosh
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=195
-  sha1: 28bb0d540b8069e4271baba6ad75c9d4e2bf8752
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=190
+  sha1: a0260b8cbcd3fba3a2885ddaa7040b8c4cb22a49
 - name: bosh-aws-cpi
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=28
   sha1: c7ce03393ebedd87a860dc609758ddb9654360fa

--- a/aws/manifest.yml.tpl
+++ b/aws/manifest.yml.tpl
@@ -108,9 +108,9 @@ jobs:
     aws: &aws
       access_key_id: ${aws_access_key_id} # <--- Replace with AWS Access Key ID
       secret_access_key: ${aws_secret_access_key} # <--- Replace with AWS Secret Key
-      default_key_name: bosh
       default_security_groups: [bosh]
       region: us-east-1
+      default_key_name: insecure-deployer
 
     agent: {mbus: "nats://nats:nats-password@10.0.0.6:4222"}
 
@@ -123,7 +123,7 @@ cloud_provider:
     host: ${aws_static_ip} # <--- Replace with your Elastic IP address
     port: 22
     user: vcap
-    private_key: ./bosh.pem # Path relative to this manifest file
+    private_key: .ssh/id_rsa # Path relative to this manifest file
 
   mbus: "https://mbus:mbus-password@${aws_static_ip}:6868" # <--- Replace with Elastic IP
 

--- a/aws/manifest.yml.tpl
+++ b/aws/manifest.yml.tpl
@@ -108,9 +108,9 @@ jobs:
     aws: &aws
       access_key_id: ${aws_access_key_id} # <--- Replace with AWS Access Key ID
       secret_access_key: ${aws_secret_access_key} # <--- Replace with AWS Secret Key
-      default_security_groups: [bosh]
-      region: us-east-1
       default_key_name: insecure-deployer
+      default_security_groups: [${bosh_security_group}]
+      region: ${aws_region}
 
     agent: {mbus: "nats://nats:nats-password@10.0.0.6:4222"}
 

--- a/aws/network.tf
+++ b/aws/network.tf
@@ -1,0 +1,32 @@
+resource "aws_eip" "bosh" {
+}
+
+resource "aws_internet_gateway" "default" {
+  vpc_id = "${aws_vpc.default.id}"
+}
+
+resource "aws_subnet" "bastion" {
+  count             = 1
+  vpc_id            = "${aws_vpc.default.id}"
+  cidr_block        = "${lookup(var.public_cidrs, concat("zone", count.index))}"
+  availability_zone = "${lookup(var.zones, concat("zone", count.index))}"
+  map_public_ip_on_launch = true
+  depends_on = ["aws_internet_gateway.default"]
+  tags {
+    Name = "${var.env}-bastion-subnet-${count.index}"
+  }
+}
+
+resource "aws_route_table" "bastion" {
+  vpc_id = "${aws_vpc.default.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.default.id}"
+  }
+}
+
+resource "aws_route_table_association" "bastion" {
+  count = 1
+  subnet_id = "${element(aws_subnet.bastion.*.id, count.index)}"
+  route_table_id = "${aws_route_table.bastion.id}"
+}

--- a/aws/network.tf
+++ b/aws/network.tf
@@ -1,4 +1,5 @@
 resource "aws_eip" "bosh" {
+  vpc = true
 }
 
 resource "aws_internet_gateway" "default" {

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,0 +1,7 @@
+output "bastion_ip" {
+  value = "${aws_instance.bastion.public_ip}"
+}
+
+output "bosh_ip" {
+	value = "${aws_eip.bosh.public_ip}"
+}

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -16,4 +16,4 @@ ssh-add ~/.ssh/id_rsa
 
 wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64
 chmod +x bosh-init-*
-./bosh-init-0.0.72-linux-amd64 deploy manifest.yml
+./bosh-init-0.0.72-linux-amd64 deploy manifest_aws.yml

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -14,6 +14,6 @@ chmod 400 ~/.ssh/id_rsa.pub
 eval `ssh-agent`
 ssh-add ~/.ssh/id_rsa
 
-wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.70-linux-amd64
+wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64
 chmod +x bosh-init-*
-./bosh-init-0.0.70-linux-amd64 deploy manifest.yml
+./bosh-init-0.0.72-linux-amd64 deploy manifest.yml

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Prepare the jumpbox to be able to install ruby and git-based bosh and cf repos
+cd $HOME
+
+sudo apt-get update
+sudo apt-get install -y build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
+
+# Set correct permissions for the ssh key we copied
+chmod 400 ~/.ssh/id_rsa
+chmod 400 ~/.ssh/id_rsa.pub
+
+# start the ssh-agent and add the keys
+eval `ssh-agent`
+ssh-add ~/.ssh/id_rsa
+
+wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.70-linux-amd64
+chmod +x bosh-init-*
+./bosh-init-0.0.70-linux-amd64 deploy manifest.yml

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -12,14 +12,13 @@ variable "zones" {
 
 variable "vpc_cidr" {
   description = "CIDR for VPC"
-  default     = "10.128.0.0/16"
+  default     = "10.0.0.0/16"
 }
 
 variable "public_cidrs" {
   description = "CIDR for public subnet indexed by AZ"
   default     = {
-    zone0 = "10.128.10.0/24"
-    zone1 = "10.128.12.0/24"
+    zone0 = "10.0.0.0/24"
   }
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,0 +1,37 @@
+variable "region"     {
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "zones" {
+  description = "AWS availability zone"
+  default     = {
+    zone0 = "eu-west-1a"
+  }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for VPC"
+  default     = "10.128.0.0/16"
+}
+
+variable "public_cidrs" {
+  description = "CIDR for public subnet indexed by AZ"
+  default     = {
+    zone0 = "10.128.10.0/24"
+    zone1 = "10.128.12.0/24"
+  }
+}
+
+variable "amis" {
+  description = "Base AMI to launch the instances with"
+  default = {
+    eu-west-1 = "ami-234ecc54"
+    eu-central-1 = "ami-9a380b87"
+  }
+}
+
+variable "key_pair_name" {
+  description = "SSH Key Pair name to be used to launch EC2 instances"
+  default     = "deployer-tsuru-example"
+}

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -1,0 +1,17 @@
+resource "google_compute_instance" "bastion" {
+  name = "${var.env}-cf-bastion"
+  machine_type = "n1-standard-1"
+  zone = "${element(split(",", var.gce_zones), count.index)}"
+  disk {
+    image = "${var.os_image}"
+  }
+  network_interface {
+    network = "${google_compute_network.bastion.name}"
+    access_config { }
+  }
+  metadata {
+    sshKeys = "${var.user}:${file("${var.ssh_key_path}")}"
+  }
+
+  tags = [ "bastion" ]
+}

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -6,7 +6,7 @@ resource "template_file" "manifest" {
         gce_project_id   =  "${var.gce_project}"
         gce_default_zone =  "${var.gce_region_zone}"
         gce_ssh_user     =  "${var.ssh_user}"
-        gce_ssh_key_path =  "/home/ubuntu/.ssh/id_rsa"
+        gce_ssh_key_path =  ".ssh/id_rsa"
         gce_microbosh_net = "${google_compute_network.bastion.name}"
     }
 }

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -20,9 +20,7 @@ resource "google_compute_instance" "bastion" {
   }
   network_interface {
     network = "${google_compute_network.bastion.name}"
-    access_config {
-      nat_ip = "${google_compute_address.bastion.address}"
-     }
+    access_config {}
   }
   metadata {
     sshKeys = "${var.user}:${file("${var.ssh_key_path}")}"
@@ -60,12 +58,6 @@ resource "google_compute_instance" "bastion" {
       destination = "/home/ubuntu/provision.sh"
   }
 
-  provisioner "remote-exec" {
-      inline = [
-          "chmod +x /home/ubuntu/provision.sh",
-          "/home/ubuntu/provision.sh",
-      ]
-  }
 }
 
 

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -1,3 +1,15 @@
+resource "template_file" "manifest" {
+    filename = "${path.module}/manifest.yml.tpl"
+
+    vars {
+        gce_static_ip    =  "${google_compute_address.bosh.address}"
+        gce_project_id   =  "${var.gce_project}"
+        gce_default_zone =  "${var.gce_region_zone}"
+        gce_ssh_user     =  "${var.ssh_user}"
+        gce_ssh_key_path =  "/home/ubuntu/.ssh/insecure-deployer"
+    }
+}
+
 resource "google_compute_instance" "bastion" {
   name = "${var.env}-cf-bastion"
   machine_type = "n1-standard-1"
@@ -12,6 +24,42 @@ resource "google_compute_instance" "bastion" {
   metadata {
     sshKeys = "${var.user}:${file("${var.ssh_key_path}")}"
   }
-
+  can_ip_forward = true
+  connection {
+    user = "${var.ssh_user}"
+    key_file = "ssh/insecure-deployer"
+  }
   tags = [ "bastion" ]
+
+  provisioner "remote-exec" {
+        inline = ["cat << EOF > /home/ubuntu/manifest.yml",
+         "${template_file.manifest.rendered}",
+         "EOF"]
+  }
+
+
+  provisioner "file" {
+          source = "${path.module}/ssh/insecure-deployer"
+          destination = "/home/ubuntu/.ssh/insecure-deployer"
+  }
+
+  provisioner "file"{
+          source = "${path.module}/account.json"
+          destination = "/home/ubuntu/account.json"
+  }
+
+  provisioner "file" {
+      source = "${path.module}/provision.sh"
+      destination = "/home/ubuntu/provision.sh"
+  }
+
+  provisioner "remote-exec" {
+      inline = [
+          "chmod +x /home/ubuntu/provision.sh",
+          "/home/ubuntu/provision.sh",
+      ]
+  }
 }
+
+
+

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -6,7 +6,8 @@ resource "template_file" "manifest" {
         gce_project_id   =  "${var.gce_project}"
         gce_default_zone =  "${var.gce_region_zone}"
         gce_ssh_user     =  "${var.ssh_user}"
-        gce_ssh_key_path =  "/home/ubuntu/.ssh/insecure-deployer"
+        gce_ssh_key_path =  "/home/ubuntu/.ssh/id_rsa"
+        gce_microbosh_net = "${google_compute_network.bastion.name}"
     }
 }
 
@@ -19,7 +20,9 @@ resource "google_compute_instance" "bastion" {
   }
   network_interface {
     network = "${google_compute_network.bastion.name}"
-    access_config { }
+    access_config {
+      nat_ip = "${google_compute_address.bastion.address}"
+     }
   }
   metadata {
     sshKeys = "${var.user}:${file("${var.ssh_key_path}")}"
@@ -37,10 +40,14 @@ resource "google_compute_instance" "bastion" {
          "EOF"]
   }
 
-
   provisioner "file" {
           source = "${path.module}/ssh/insecure-deployer"
-          destination = "/home/ubuntu/.ssh/insecure-deployer"
+          destination = "/home/ubuntu/.ssh/id_rsa"
+  }
+
+  provisioner "file" {
+          source = "${path.module}/ssh/insecure-deployer.pub"
+          destination = "/home/ubuntu/.ssh/id_rsa.pub"
   }
 
   provisioner "file"{

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -1,0 +1,13 @@
+resource "google_compute_firewall" "ssh" {
+  name = "${var.env}-cf-nat"
+  description = "SSH from trusted external sources"
+  network = "${google_compute_network.bastion.name}"
+
+  source_ranges = [ "${split(",", var.office_cidrs)}" ]
+  target_tags = [ "bastion" ]
+
+  allow {
+    protocol = "tcp"
+    ports = [ 22 ]
+  }
+}

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -16,7 +16,7 @@ resource "google_compute_firewall" "bosh-nat" {
   name = "${var.env}-cf-microbosh-nat"
   description = "SSH and Bosh ports from trusted external sources"
   network = "${google_compute_network.bastion.name}"
-  source_ranges = [ "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}" ]
+  source_ranges = [ "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}", "${split(",", var.office_cidrs)}" ]
   target_tags = [ "bosh" ]
   allow {
     protocol = "tcp"

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -4,7 +4,7 @@ resource "google_compute_firewall" "ssh" {
   network = "${google_compute_network.bastion.name}"
 
   source_ranges = [ "${split(",", var.office_cidrs)}" ]
-  target_tags = [ "bastion" ]
+  target_tags = [ "bastion","bosh" ]
 
   allow {
     protocol = "tcp"
@@ -14,8 +14,9 @@ resource "google_compute_firewall" "ssh" {
 
 resource "google_compute_firewall" "ssh-bosh" {
   name = "${var.env}-cf-microbosh"
-  description = "SSH from trusted external sources"
+  description = "SSH and Bosh ports from trusted external sources"
   network = "${google_compute_network.bastion.name}"
+  source_tags = [ "bastion" ]
   target_tags = [ "bosh" ]
   allow {
     protocol = "tcp"
@@ -23,3 +24,19 @@ resource "google_compute_firewall" "ssh-bosh" {
   }
 
 }
+
+resource "google_compute_firewall" "bosh-nat" {
+  name = "${var.env}-cf-microbosh-nat"
+  description = "SSH and Bosh ports from trusted external sources"
+  network = "${google_compute_network.bastion.name}"
+  source_ranges = [ "${google_compute_address.bastion.address}" ]
+  target_tags = [ "bosh" ]
+  allow {
+    protocol = "tcp"
+    ports = [ 22, 4222, 6868, 25250, 25555, 25777 ]
+  }
+
+}
+
+
+

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -12,24 +12,11 @@ resource "google_compute_firewall" "ssh" {
   }
 }
 
-resource "google_compute_firewall" "ssh-bosh" {
-  name = "${var.env}-cf-microbosh"
-  description = "SSH and Bosh ports from trusted external sources"
-  network = "${google_compute_network.bastion.name}"
-  source_tags = [ "bastion" ]
-  target_tags = [ "bosh" ]
-  allow {
-    protocol = "tcp"
-    ports = [ 22, 4222, 6868, 25250, 25555, 25777 ]
-  }
-
-}
-
 resource "google_compute_firewall" "bosh-nat" {
   name = "${var.env}-cf-microbosh-nat"
   description = "SSH and Bosh ports from trusted external sources"
   network = "${google_compute_network.bastion.name}"
-  source_ranges = [ "${google_compute_address.bastion.address}" ]
+  source_ranges = [ "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}" ]
   target_tags = [ "bosh" ]
   allow {
     protocol = "tcp"

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -11,3 +11,15 @@ resource "google_compute_firewall" "ssh" {
     ports = [ 22 ]
   }
 }
+
+resource "google_compute_firewall" "ssh-bosh" {
+  name = "${var.env}-cf-microbosh"
+  description = "SSH from trusted external sources"
+  network = "${google_compute_network.bastion.name}"
+  target_tags = [ "bosh" ]
+  allow {
+    protocol = "tcp"
+    ports = [ 22, 4222, 6868, 25250, 25555, 25777 ]
+  }
+
+}

--- a/gce/globals.tf
+++ b/gce/globals.tf
@@ -1,0 +1,1 @@
+../globals.tf

--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -1,0 +1,169 @@
+---
+name: bosh
+
+releases:
+  - name: bosh
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=194
+    sha1: d24d5c60419c1c21bb47aa87f3cb6cf2234f9332
+  - name: bosh-google-cpi
+    url: http://storage.googleapis.com/bosh-stemcells/bosh-google-cpi-5.tgz
+    sha1: c5de3053f233e6ef42c2a4228fa94179d955cc84
+
+resource_pools:
+  - name: vms
+    network: private
+    stemcell:
+      url: http://storage.googleapis.com/bosh-stemcells/light-bosh-stemcell-2968-google-kvm-ubuntu-trusty-go_agent.tgz
+      sha1: ce5a64c3ecef4fd3e6bd633260dfaa7de76540eb
+    cloud_properties:
+      machine_type: n1-standard-2
+      root_disk_size_gb: 40
+      root_disk_type: pd-standard
+
+disk_pools:
+  - name: disks
+    disk_size: 32_768
+    cloud_properties:
+      type: pd-standard
+
+networks:
+  - name: private
+    type: dynamic
+    cloud_properties:
+      network_name: default
+      tags:
+        - bosh
+
+  - name: public
+    type: vip
+
+jobs:
+  - name: bosh
+    instances: 1
+
+    templates:
+      - name: nats
+        release: bosh
+      - name: redis
+        release: bosh
+      - name: postgres
+        release: bosh
+      - name: powerdns
+        release: bosh
+      - name: blobstore
+        release: bosh
+      - name: director
+        release: bosh
+      - name: health_monitor
+        release: bosh
+      - name: cpi
+        release: bosh-google-cpi
+      - name: registry
+        release: bosh-google-cpi
+
+    resource_pool: vms
+    persistent_disk_pool: disks
+
+    networks:
+      - name: private
+        default:
+          - dns
+          - gateway
+      - name: public
+        static_ips:
+          - ${gce_static_ip}
+
+    properties:
+      nats:
+        address: 127.0.0.1
+        user: nats
+        password: nats
+
+      redis:
+        listen_address: 127.0.0.1
+        address: 127.0.0.1
+        password: redis
+
+      postgres: &db
+        adapter: postgres
+        host: 127.0.0.1
+        user: postgres
+        password: postgres
+        database: bosh
+
+      dns:
+        address: ${gce_static_ip}
+        domain_name: microbosh
+        db: *db
+        recursor: 8.8.8.8
+
+      blobstore:
+        address: ${gce_static_ip}
+        provider: dav
+        director:
+          user: director
+          password: director
+        agent:
+          user: agent
+          password: agent
+
+      director:
+        address: 127.0.0.1
+        name: micro-google
+        db: *db
+        cpi_job: cpi
+
+      hm:
+        http:
+          user: hm
+          password: hm
+        director_account:
+          user: admin
+          password: admin123
+        resurrector_enabled: true
+
+      ntp: &ntp
+        - 169.254.169.254
+
+      google: &google_properties
+        project: ${gce_project_id}
+        json_key: |
+                    ACCOUNT_JSON
+        default_zone: ${gce_default_zone}
+
+      agent:
+        mbus: nats://nats:nats@${gce_static_ip}:4222
+        ntp: *ntp
+        blobstore:
+           options:
+             endpoint: http://${gce_static_ip}:25250
+             user: agent
+             password: agent
+
+      registry:
+        host: ${gce_static_ip}
+        username: registry
+        password: registry
+
+cloud_provider:
+  template:
+    name: cpi
+    release: bosh-google-cpi
+
+  ssh_tunnel:
+    host: ${gce_static_ip}
+    port: 22
+    user: ${gce_ssh_user}
+    private_key: ${gce_ssh_key_path}
+
+  mbus: https://mbus:mbus@${gce_static_ip}:6868
+
+  properties:
+    google: *google_properties
+    agent:
+      mbus: https://mbus:mbus@0.0.0.0:6868
+      ntp: *ntp
+      blobstore:
+        provider: local
+        options:
+          blobstore_path: /var/vcap/micro_bosh/data/cache

--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -11,7 +11,7 @@ releases:
 
 resource_pools:
   - name: vms
-    network: private
+    network: public
     stemcell:
       url: http://storage.googleapis.com/bosh-stemcells/light-bosh-stemcell-2968-google-kvm-ubuntu-trusty-go_agent.tgz
       sha1: ce5a64c3ecef4fd3e6bd633260dfaa7de76540eb
@@ -30,9 +30,10 @@ networks:
   - name: private
     type: dynamic
     cloud_properties:
-      network_name: default
+      network_name: ${gce_microbosh_net}
       tags:
         - bosh
+        - bastion
 
   - name: public
     type: vip

--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -3,8 +3,8 @@ name: bosh
 
 releases:
   - name: bosh
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=194
-    sha1: d24d5c60419c1c21bb47aa87f3cb6cf2234f9332
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=168
+    sha1: 57320a93a7a15e51af4c57d9d9c22706c45c9953
   - name: bosh-google-cpi
     url: http://storage.googleapis.com/bosh-stemcells/bosh-google-cpi-5.tgz
     sha1: c5de3053f233e6ef42c2a4228fa94179d955cc84

--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -3,8 +3,8 @@ name: bosh
 
 releases:
   - name: bosh
-    url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=168
-    sha1: 57320a93a7a15e51af4c57d9d9c22706c45c9953
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=190
+    sha1: a0260b8cbcd3fba3a2885ddaa7040b8c4cb22a49
   - name: bosh-google-cpi
     url: http://storage.googleapis.com/bosh-stemcells/bosh-google-cpi-5.tgz
     sha1: c5de3053f233e6ef42c2a4228fa94179d955cc84

--- a/gce/network.tf
+++ b/gce/network.tf
@@ -1,0 +1,4 @@
+resource "google_compute_network" "bastion" {
+  name = "${var.env}-cf-bastion"
+  ipv4_range = "${var.bastion_cidr}"
+}

--- a/gce/network.tf
+++ b/gce/network.tf
@@ -3,6 +3,11 @@ resource "google_compute_network" "bastion" {
   ipv4_range = "${var.bastion_cidr}"
 }
 
+resource "google_compute_address" "bastion" {
+    name = "${var.env}-bastion"
+}
+
 resource "google_compute_address" "bosh" {
     name = "${var.env}-bosh"
 }
+

--- a/gce/network.tf
+++ b/gce/network.tf
@@ -2,3 +2,7 @@ resource "google_compute_network" "bastion" {
   name = "${var.env}-cf-bastion"
   ipv4_range = "${var.bastion_cidr}"
 }
+
+resource "google_compute_address" "bosh" {
+    name = "${var.env}-bosh"
+}

--- a/gce/network.tf
+++ b/gce/network.tf
@@ -3,10 +3,6 @@ resource "google_compute_network" "bastion" {
   ipv4_range = "${var.bastion_cidr}"
 }
 
-resource "google_compute_address" "bastion" {
-    name = "${var.env}-bastion"
-}
-
 resource "google_compute_address" "bosh" {
     name = "${var.env}-bosh"
 }

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -1,0 +1,3 @@
+output "bastion_ip" {
+  value = "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}"
+}

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -1,3 +1,6 @@
 output "bastion_ip" {
   value = "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}"
 }
+output "bosh_ip" {
+	value = "${google_compute_address.bosh.address}"
+}

--- a/gce/provider.tf
+++ b/gce/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  account_file = "${var.gce_account_file}"
+  project = "${var.gce_project}"
+  region = "${var.gce_region}"
+}

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -6,10 +6,18 @@ cd $HOME
 sudo apt-get update
 sudo apt-get install -y build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
 
+# Set correct permissions for the ssh key we copied
+chmod 400 ~/.ssh/id_rsa
+chmod 400 ~/.ssh/id_rsa.pub
+
 # Generate the key that will be used to ssh between the inception server and the
 # microbosh machine
-ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+#ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
 
+# start the ssh-agent and add the keys
+eval `ssh-agent`
+#ssh-add ~/.ssh/insecure-deployer
+ssh-add ~/.ssh/id_rsa
 
 # account.json file exists
 # Variable to replace in Yaml file: ACOUNT_JSON

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Prepare the jumpbox to be able to install ruby and git-based bosh and cf repos
+cd $HOME
+
+sudo apt-get update
+sudo apt-get install -y build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
+
+# Generate the key that will be used to ssh between the inception server and the
+# microbosh machine
+ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+
+
+# account.json file exists
+# Variable to replace in Yaml file: ACOUNT_JSON
+
+
+tr -d '\n' < account.json > account_tmp.json
+python -c 'print open("manifest.yml").read().replace("ACCOUNT_JSON", open("account_tmp.json").read()).rstrip().rstrip("EOF")' > manifest_gce.yml 2>&1
+rm account_tmp.json
+
+wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.70-linux-amd64
+chmod +x bosh-init-*
+./bosh-init-0.0.70-linux-amd64 deploy manifest_gce.yml

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -27,6 +27,6 @@ tr -d '\n' < account.json > account_tmp.json
 python -c 'print open("manifest.yml").read().replace("ACCOUNT_JSON", open("account_tmp.json").read()).rstrip().rstrip("EOF")' > manifest_gce.yml 2>&1
 rm account_tmp.json
 
-wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.70-linux-amd64
+wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64
 chmod +x bosh-init-*
-./bosh-init-0.0.70-linux-amd64 deploy manifest_gce.yml
+./bosh-init-0.0.72-linux-amd64 deploy manifest_gce.yml

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -13,6 +13,11 @@ variable "gce_region" {
   default = "europe-west1"
 }
 
+variable "gce_region_zone" {
+  description = "GCE Region to use"
+  default = "europe-west1-b"
+}
+
 variable "gce_zones" {
   description = "GCE Zones to choose from"
   default = "europe-west1-b,europe-west1-c,europe-west1-d"

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -32,3 +32,8 @@ variable "os_image" {
   description = "OS image to boot VMs using"
   default = "ubuntu-1404-trusty-v20150316"
 }
+
+variable "bastion_cidr" {
+  description = "CIDR for bastion network"
+  default = "10.10.0.0/24"
+}

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -1,0 +1,34 @@
+variable "gce_account_file" {
+  description = "JSON Account Credentials file for GCE"
+  default = "account.json"
+}
+
+variable "gce_project" {
+  description = "GCE Project Name to create machines inside of"
+  default = "root-unison-859"
+}
+
+variable "gce_region" {
+  description = "GCE Region to use"
+  default = "europe-west1"
+}
+
+variable "gce_zones" {
+  description = "GCE Zones to choose from"
+  default = "europe-west1-b,europe-west1-c,europe-west1-d"
+}
+
+variable "ssh_key_path" {
+  description = "Path to the ssh key to use"
+  default = "ssh/insecure-deployer.pub"
+}
+
+variable "user" {
+  description = "User account to set up SSH keys for"
+  default = "ubuntu"
+}
+
+variable "os_image" {
+  description = "OS image to boot VMs using"
+  default = "ubuntu-1404-trusty-v20150316"
+}

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -42,3 +42,4 @@ variable "bastion_cidr" {
   description = "CIDR for bastion network"
   default = "10.10.0.0/24"
 }
+

--- a/globals.tf
+++ b/globals.tf
@@ -1,0 +1,3 @@
+variable "env" {
+  description = "Environment name"
+}

--- a/globals.tf
+++ b/globals.tf
@@ -7,7 +7,6 @@ variable "office_cidrs" {
   default     = "80.194.77.90/32,80.194.77.100/32"
 }
 
-
 variable "ssh_user" {
 	description = "Username used to ssh into VMs."
 	default     = "ubuntu"

--- a/globals.tf
+++ b/globals.tf
@@ -1,3 +1,8 @@
 variable "env" {
   description = "Environment name"
 }
+
+variable "office_cidrs" {
+  description = "CSV of CIDR addresses for our office which will be trusted"
+  default     = "80.194.77.90/32,80.194.77.100/32"
+}

--- a/globals.tf
+++ b/globals.tf
@@ -6,3 +6,9 @@ variable "office_cidrs" {
   description = "CSV of CIDR addresses for our office which will be trusted"
   default     = "80.194.77.90/32,80.194.77.100/32"
 }
+
+
+variable "ssh_user" {
+	description = "Username used to ssh into VMs."
+	default     = "ubuntu"
+}


### PR DESCRIPTION
## What

We have agreed to start our CF test by using the microBOSH and scaling to full BOSH only if needed. This story is to create the first infrastructure needed for the CF build out by creating microBOSH instances in AWS + GCE.

Please refer to the README for implementation details.
## How to review

Create the microBOSH VM on each cloud by following the instructions in the README. The success criteria is having the bastion created, the bosh-init script running and creating the BOSH VM until getting messages such as:

```
Waiting for instance 'bosh/0' to be running...
Finished (00:00:12)
```

**Please note:**
- it takes about 15 min for each platform
- there is an intermittent issue on GCE whereby the BOSH VM does not always listen on SSH port and leaves the bosh-init script hanging. The workaround is to reset the VM via the GCE console and the bosh-init script should continue
## Who should review

Anyone but @jimconner and @saliceti
