### PR TITLE
[#100412960] Consistently use same name for bosh-init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ provision: check-env-vars
 bosh-delete-aws: set-aws bosh-delete
 bosh-delete-gce: set-gce bosh-delete
 bosh-delete:
-	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) './`ls bosh-init-*` delete manifest_${dir}.yml'
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) './bosh-init delete manifest_${dir}.yml'
 
 destroy-aws: set-aws destroy
 destroy-gce: set-gce destroy

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -14,6 +14,6 @@ chmod 400 ~/.ssh/id_rsa.pub
 eval `ssh-agent`
 ssh-add ~/.ssh/id_rsa
 
-wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64
-chmod +x bosh-init-*
-./bosh-init-0.0.72-linux-amd64 deploy manifest_aws.yml
+wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64 -O bosh-init
+chmod +x bosh-init
+./bosh-init deploy manifest_aws.yml

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -27,6 +27,6 @@ tr -d '\n' < account.json > account_tmp.json
 python -c 'print open("manifest.yml").read().replace("ACCOUNT_JSON", open("account_tmp.json").read()).rstrip().rstrip("EOF")' > manifest_gce.yml 2>&1
 rm account_tmp.json
 
-wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64
-chmod +x bosh-init-*
-./bosh-init-0.0.72-linux-amd64 deploy manifest_gce.yml
+wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64 -O bosh-init
+chmod +x bosh-init
+./bosh-init deploy manifest_gce.yml


### PR DESCRIPTION
# What

Part of [#100412960] Terrraform deployment for MicroBOSH, we missed a small bug.

When downloading `bosh-init`, save it as `$HOME/bosh_init`. This
simplifies how is used in later steps and avoids issues like duplicated
binaries when running the deployment twice.

Previously, running the deployment twice and trying to run `make
bosh-delete` would end with a error.
# How to review it

Confirm that the behaviour is the same and we still can deploy the both environments as described in #1 
# Who can review it

Anyone but @keymon
