### PR TITLE
[#102465348] Open ports on GCE for bosh-deployed VMs

### DIFF
--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -12,18 +12,46 @@ resource "google_compute_firewall" "ssh" {
   }
 }
 
+resource "google_compute_firewall" "boshbosh" {
+  name = "${var.env}-boshbosh"
+  description = "SSH from trusted external sources"
+  network = "${google_compute_network.bastion.name}"
+
+  source_tags = [ "bosh" ]
+  target_tags = [ "bosh" ]
+
+  allow {
+    protocol = "tcp"
+  }
+}
+
+resource "google_compute_firewall" "boshdns" {
+  name = "${var.env}-cf-boshdns"
+  description = "Allow anything/anywhere to hit port 53 on machines tagges as bosh"
+  network = "${google_compute_network.bastion.name}"
+  source_ranges = [ "0.0.0.0/0" ]
+  target_tags = [ "bosh" ]
+  allow {
+    protocol = "udp"
+    ports = [ 53 ]
+  }
+
+}
+
 resource "google_compute_firewall" "bosh-nat" {
   name = "${var.env}-cf-microbosh-nat"
   description = "SSH and Bosh ports from trusted external sources"
   network = "${google_compute_network.bastion.name}"
-  source_ranges = [ "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}", "${split(",", var.office_cidrs)}" ]
+  source_ranges = [ "0.0.0.0/0" ]
   target_tags = [ "bosh" ]
   allow {
     protocol = "tcp"
-    ports = [ 22, 4222, 6868, 25250, 25555, 25777 ]
+    ports = [ 22, 80, 443, 4222, 6868, 25250, 25555, 25777 ]
   }
 
 }
+
+
 
 
 


### PR DESCRIPTION
[Create NATS instnace in CF environment on GCE](https://www.pivotaltracker.com/story/show/102465348)

**What**

The bosh deployed VMs need to communicate with the microbosh on a number of different TCP and UDP ports in order to get their configuration information, fetch packages, resolve DNS and perform
logging. Due to the weakness in GCE's network implementation, this essentially involves either opening those ports to the world, or running all outbound traffic through a SPOF address translation box so that outbound traffic comes from a known-good IP address.

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I need some additional TCP and UDP ports opened to allow traffic from bosh-deployed VMs to communicate with BOSH.
- Due to the way that GCE networking works with randomly assigned ephemeral IP addresses, I understand that unless we are using a masquerading-nat-proxy machine, the only way to achieve this is opening the ports with a source range of 0.0.0.0/0
- The objective at this stage is to make bosh deployments function correctly - a follow-on story will look at improving the network security around these services.

**How to test this PR**

Use the Makefile to deploy a microbosh instance onto gce (using the deploy-gce command within the Makefile)

Confirm that security groups are created for your network as follows:
- <env_name>-boshbosh - Allow all TCP traffic between source tags of 'bosh' and destination tags of 'bosh'
- <env_name>-cf-boshdns - Allow UDP/53 DNS resolution traffic to machines tagged as 'bosh' from a source of 0.0.0.0/0
- <env_name>-cf-microbosh-nat - Allow TCP ports 80, 443, 4222, 6868, 25250, 25555 and 25777 with a source IP of 0.0.0.0/0 to machines tagged as 'bosh'
- <env_name>-cf-nat - Allow TCP/22 (ssh) traffic from Office CIDR addresses only.

**Who should review this PR**
- Anyone in the core team except @mtekel who I paired with :-p

**Notes**

There will be a follow up story after this one to improve network security - The point of this PR is solely to allow deployments to succeed.
