### PR TITLE
[101129996] Install cloudfoundry nats service on AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ prepare-provision:
 provision-aws: set-aws prepare-provision provision
 provision-gce: set-gce provision
 provision: check-env-vars
-	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash provision.sh'
+	@ssh -t -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash provision.sh'
 
 bosh-delete-aws: set-aws bosh-delete
 bosh-delete-gce: set-gce bosh-delete

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ set-aws:
 set-gce:
 	$(eval dir=gce)
 
-aws: set-aws apply prepare-provision provision
+aws: set-aws apply prepare-provision provision provision-cf-aws
 gce: set-gce apply provision
 
 apply-aws: set-aws apply
@@ -23,7 +23,6 @@ apply: check-env-vars
 
 prepare-provision:
 	@cd ${dir} && scp -oStrictHostKeyChecking=no provision.sh ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip):provision.sh
-	@cd ${dir} && scp -oStrictHostKeyChecking=no cf-manifest.yml ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip):cf-manifest.yml
 	@cd ${dir} && scp -oStrictHostKeyChecking=no manifest.yml ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip):manifest_${dir}.yml
 
 provision-aws: set-aws prepare-provision provision
@@ -35,6 +34,13 @@ bosh-delete-aws: set-aws bosh-delete
 bosh-delete-gce: set-gce bosh-delete
 bosh-delete:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) './bosh-init delete manifest_${dir}.yml'
+
+provision-cf-aws: set-aws provision-cf
+provision-cf:
+	@cd ${dir} && scp -oStrictHostKeyChecking=no cf-manifest.yml ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip):cf-manifest.yml
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) 'sed -i "s/BOSH_UUID/$$(bosh status --uuid)/" cf-manifest.yml'
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) 'bosh deployment cf-manifest.yml'
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) 'bosh deploy'
 
 destroy-aws: set-aws destroy
 destroy-gce: set-gce destroy

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ set-aws:
 set-gce:
 	$(eval dir=gce)
 
-aws: set-aws apply provision
+aws: set-aws apply prepare-provision provision
 gce: set-gce apply provision
 
 apply-aws: set-aws apply
@@ -21,7 +21,12 @@ apply-gce: set-gce apply
 apply: check-env-vars
 	@cd ${dir} && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV}
 
-provision-aws: set-aws provision
+prepare-provision:
+	@cd ${dir} && scp -oStrictHostKeyChecking=no provision.sh ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip):provision.sh
+	@cd ${dir} && scp -oStrictHostKeyChecking=no cf-manifest.yml ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip):cf-manifest.yml
+	@cd ${dir} && scp -oStrictHostKeyChecking=no manifest.yml ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip):manifest_${dir}.yml
+
+provision-aws: set-aws prepare-provision provision
 provision-gce: set-gce provision
 provision: check-env-vars
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash provision.sh'

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -9,7 +9,7 @@ resource "template_file" "manifest" {
     filename = "${path.module}/manifest.yml.tpl"
 
     vars {
-        aws_static_ip    =  "${aws_eip.bosh.public_ip}"
+        aws_static_ip    =  "${var.microbosh_IP}"
         aws_subnet_id    =  "${aws_subnet.bastion.0.id}"
         aws_availability_zone = "${var.zones.zone0}"
         aws_secret_access_key = "${var.AWS_SECRET_ACCESS_KEY}"

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -29,7 +29,6 @@ resource "template_file" "cf_manifest" {
         default_security_group  = "${aws_security_group.bosh_vm.name}"
         nats_security_group     = "${aws_security_group.nats.name}"
     }
-    }
 }
 
 resource "aws_instance" "bastion" {

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -3,6 +3,7 @@ resource "aws_instance" "bastion" {
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.bastion.0.id}"
   private_ip = "10.0.0.4"
+  associate_public_ip_address = true
   vpc_security_group_ids = ["${aws_security_group.bastion.id}"]
   key_name = "${var.key_pair_name}"
   source_dest_check = false

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -26,6 +26,12 @@ resource "aws_instance" "bastion" {
   security_groups = ["${aws_security_group.bastion.id}"]
   key_name = "${var.key_pair_name}"
   source_dest_check = false
+
+  root_block_device = {
+    volume_type = "gp2"
+    volume_size = 100
+  }
+
   tags = {
     Name = "${var.env}-bastion"
   }

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -1,36 +1,3 @@
-# Terraform currently only has limited support for reading environment variables
-# Variables for use with terraform must be prefexed with 'TF_VAR_'
-# These two variables are passed in as environment variables named:
-# TF_VAR_AWS_ACCESS_KEY_ID and TF_VAR_AWS_SECRET_ACCESS_KEY respectively
-variable "AWS_ACCESS_KEY_ID" {}
-variable "AWS_SECRET_ACCESS_KEY" {}
-
-resource "template_file" "manifest" {
-    filename = "${path.module}/manifest.yml.tpl"
-
-    vars {
-        aws_static_ip           =  "${var.microbosh_IP}"
-        aws_subnet_id           =  "${aws_subnet.bastion.0.id}"
-        aws_availability_zone   = "${var.zones.zone0}"
-        aws_secret_access_key   = "${var.AWS_SECRET_ACCESS_KEY}"
-        aws_access_key_id       = "${var.AWS_ACCESS_KEY_ID}"
-        aws_region              = "${var.region}"
-        bosh_security_group     = "${aws_security_group.director.name}"
-        default_security_group  = "${aws_security_group.bosh_vm.name}"
-    }
-}
-
-resource "template_file" "cf_manifest" {
-    filename = "${path.module}/cf-manifest.yml.tpl"
-
-    vars {
-        aws_subnet_id           = "${aws_subnet.bastion.0.id}"
-        aws_availability_zone   = "${var.zones.zone0}"
-        default_security_group  = "${aws_security_group.bosh_vm.name}"
-        nats_security_group     = "${aws_security_group.nats.name}"
-    }
-}
-
 resource "aws_instance" "bastion" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.micro"

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -20,18 +20,6 @@ resource "aws_instance" "bastion" {
     key_file = "ssh/insecure-deployer"
   }
 
-  provisioner "remote-exec" {
-        inline = ["cat << EOF > /home/ubuntu/manifest_aws.yml",
-         "${template_file.manifest.rendered}",
-         "EOF"]
-  }
-
-  provisioner "remote-exec" {
-        inline = ["cat << EOF > /home/ubuntu/cf_manifest_aws.yml",
-         "${template_file.cf_manifest.rendered}",
-         "EOF"]
-  }
-
   provisioner "file" {
           source = "${path.module}/ssh/insecure-deployer"
           destination = "/home/ubuntu/.ssh/id_rsa"
@@ -42,8 +30,4 @@ resource "aws_instance" "bastion" {
           destination = "/home/ubuntu/.ssh/id_rsa.pub"
   }
 
-  provisioner "file" {
-      source = "${path.module}/provision.sh"
-      destination = "/home/ubuntu/provision.sh"
-  }
 }

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -23,7 +23,8 @@ resource "aws_instance" "bastion" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.bastion.0.id}"
-  security_groups = ["${aws_security_group.bastion.id}"]
+  private_ip = "10.0.0.4"
+  vpc_security_group_ids = ["${aws_security_group.bastion.id}"]
   key_name = "${var.key_pair_name}"
   source_dest_check = false
 

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -9,13 +9,17 @@ resource "template_file" "manifest" {
     filename = "${path.module}/manifest.yml.tpl"
 
     vars {
-        aws_static_ip    =  "${var.microbosh_IP}"
-        aws_subnet_id    =  "${aws_subnet.bastion.0.id}"
-        aws_availability_zone = "${var.zones.zone0}"
-        aws_secret_access_key = "${var.AWS_SECRET_ACCESS_KEY}"
-        aws_access_key_id = "${var.AWS_ACCESS_KEY_ID}"
-        aws_region       = "${var.region}"
-        bosh_security_group = "${var.env}-cf-microbosh"
+        aws_static_ip           =  "${var.microbosh_IP}"
+        aws_subnet_id           =  "${aws_subnet.bastion.0.id}"
+        aws_availability_zone   = "${var.zones.zone0}"
+        aws_secret_access_key   = "${var.AWS_SECRET_ACCESS_KEY}"
+        aws_access_key_id       = "${var.AWS_ACCESS_KEY_ID}"
+        aws_region              = "${var.region}"
+        bosh_security_group     = "${aws_security_group.director.name}"
+        default_security_group  = "${aws_security_group.bosh_vm.name}"
+    }
+}
+
     }
 }
 

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -25,6 +25,7 @@ resource_pools:
   cloud_properties:
     instance_type: t2.small
     availability_zone: ${aws_availability_zone}
+    ephemeral_disk: {size: 25_000, type: gp2}
 
 compilation:
   workers: 3

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -17,7 +17,7 @@ networks:
     cloud_properties: {subnet: ${aws_subnet_id}}
 
 resource_pools:
-- name: small_z1
+- name: small_nats_z1
   network: private
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
@@ -26,6 +26,9 @@ resource_pools:
     instance_type: t2.small
     availability_zone: ${aws_availability_zone}
     ephemeral_disk: {size: 25_000, type: gp2}
+    security_groups:
+    - ${default_security_group}
+    - ${nats_security_group}
 
 compilation:
   workers: 3
@@ -46,14 +49,12 @@ update:
 jobs:
 - name: nats_z1
   instances: 1
-  resource_pool: small_z1
+  resource_pool: small_nats_z1
   templates:
   - {name: nats, release: cf}
   networks:
   - name: private
     static_ips: [10.0.0.10]
-    cloud_properties:
-      security_groups: [${default_security_group}, ${nats_security_group}]
 
 properties:
   description: Cloud Foundry for Government PaaS

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -1,6 +1,6 @@
 ---
 name: CloudFoundry manifest
-director_uuid: TODO
+director_uuid: BOSH_UUID
 
 releases:
 - {name: cf, version: 210}

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -3,7 +3,7 @@ name: CloudFoundry
 director_uuid: BOSH_UUID
 
 releases:
-- {name: cf, version: 210}
+- {name: cf, version: 215}
 
 networks:
 - name: private

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -1,5 +1,5 @@
 ---
-name: CloudFoundry manifest
+name: CloudFoundry
 director_uuid: BOSH_UUID
 
 releases:

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -20,8 +20,8 @@ resource_pools:
 - name: small_z1
   network: private
   stemcell:
-    name: bosh-aws-xen-ubuntu-trusty-go_agent
-    version: 3056
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: 3063
   cloud_properties:
     instance_type: t2.small
 

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -1,0 +1,66 @@
+---
+name: CloudFoundry manifest
+director_uuid: TODO
+
+releases:
+- {name: cf, version: 210}
+
+networks:
+- name: private
+  type: manual
+  subnets:
+  - range: 10.0.0.0/24
+    gateway: 10.0.0.1
+    dns: [10.0.0.2]
+    reserved: ["10.0.0.2 - 10.0.0.9"]
+    static: ["10.0.0.10 - 10.0.0.100"]
+    cloud_properties: {subnet: ${aws_subnet_id}}
+
+resource_pools:
+- name: small_z1
+  network: private
+  stemcell:
+    name: bosh-aws-xen-ubuntu-trusty-go_agent
+    version: 3056
+  cloud_properties:
+    instance_type: t2.small
+
+compilation:
+  workers: 1
+  network: private
+  reuse_compilation_vms: true
+  cloud_properties:
+    instance_type: t2.medium
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  serial: false
+  canary_watch_time: 30000-600000
+  update_watch_time: 5000-600000
+
+jobs:
+- name: nats_z1
+  instances: 1
+  resource_pool: small_z1
+  templates:
+  - {name: nats, release: cf}
+  networks:
+  - name: private
+    static_ips: [10.0.0.10]
+    cloud_properties:
+      security_groups: [${default_security_group}, ${nats_security_group}]
+
+properties:
+  description: Cloud Foundry for Government PaaS
+  networks: {apps: private}
+  nats:
+    machines: [10.0.0.10]
+    password: PASSWORD
+    port: 4222
+    user: nats
+  ssl:
+    skip_cert_verify: true
+  cloud_properties:
+    availability_zone: ${aws_availability_zone}
+    ephemeral_disk: {size: 25_000, type: gp2}

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -24,13 +24,16 @@ resource_pools:
     version: 3063
   cloud_properties:
     instance_type: t2.small
+    availability_zone: ${aws_availability_zone}
 
 compilation:
-  workers: 1
+  workers: 3
   network: private
   reuse_compilation_vms: true
   cloud_properties:
-    instance_type: t2.medium
+    instance_type: c3.large
+    availability_zone: ${aws_availability_zone}
+    ephemeral_disk: {size: 25_000, type: gp2}
 
 update:
   canaries: 1
@@ -61,6 +64,3 @@ properties:
     user: nats
   ssl:
     skip_cert_verify: true
-  cloud_properties:
-    availability_zone: ${aws_availability_zone}
-    ephemeral_disk: {size: 25_000, type: gp2}

--- a/aws/cf-manifest.yml.tpl
+++ b/aws/cf-manifest.yml.tpl
@@ -26,9 +26,6 @@ resource_pools:
     instance_type: t2.small
     availability_zone: ${aws_availability_zone}
     ephemeral_disk: {size: 25_000, type: gp2}
-    security_groups:
-    - ${default_security_group}
-    - ${nats_security_group}
 
 compilation:
   workers: 3

--- a/aws/firewall.tf
+++ b/aws/firewall.tf
@@ -121,5 +121,31 @@ resource "aws_security_group" "bosh_vm" {
   tags {
     Name = "${var.env}-bosh-vm"
   }
+}
 
+resource "aws_security_group" "nats" {
+  name = "${var.env}-nats"
+  description = "Security group for NATS"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 4222
+    to_port   = 4222
+    protocol  = "tcp"
+    security_groups = [
+      "${aws_security_group.bastion.id}",
+      "${aws_security_group.bosh_vm.id}",
+    ]
+  }
+
+  tags {
+    Name = "${var.env}-nats"
+  }
 }

--- a/aws/firewall.tf
+++ b/aws/firewall.tf
@@ -109,12 +109,10 @@ resource "aws_security_group" "bosh_vm" {
   }
 
   ingress {
-    from_port = 22
-    to_port   = 22
-    protocol  = "tcp"
-    security_groups = [
-      "${aws_security_group.bastion.id}",
-    ]
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["${var.vpc_cidr}"]
   }
 
   tags {

--- a/aws/firewall.tf
+++ b/aws/firewall.tf
@@ -122,29 +122,3 @@ resource "aws_security_group" "bosh_vm" {
   }
 }
 
-resource "aws_security_group" "nats" {
-  name = "${var.env}-nats"
-  description = "Security group for NATS"
-  vpc_id = "${aws_vpc.default.id}"
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 4222
-    to_port   = 4222
-    protocol  = "tcp"
-    security_groups = [
-      "${aws_security_group.bastion.id}",
-      "${aws_security_group.bosh_vm.id}",
-    ]
-  }
-
-  tags {
-    Name = "${var.env}-nats"
-  }
-}

--- a/aws/firewall.tf
+++ b/aws/firewall.tf
@@ -38,42 +38,42 @@ resource "aws_security_group" "bosh-ports" {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
+    cidr_blocks = ["${aws_instance.bastion.private_ip}/32"]
   }
 
   ingress {
     from_port = 4222
     to_port   = 4222
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
+    cidr_blocks = ["${aws_instance.bastion.private_ip}/32"]
   }
 
   ingress {
     from_port = 6868
     to_port   = 6868
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
+    cidr_blocks = ["${aws_instance.bastion.private_ip}/32"]
   }
 
   ingress {
     from_port = 25250
     to_port   = 25250
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
+    cidr_blocks = ["${aws_instance.bastion.private_ip}/32"]
   }
 
   ingress {
     from_port = 25555
     to_port   = 25555
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
+    cidr_blocks = ["${aws_instance.bastion.private_ip}/32"]
   }
 
   ingress {
     from_port = 25777
     to_port   = 25777
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}", "${aws_instance.bastion.public_ip}/32"]
+    cidr_blocks = ["${aws_instance.bastion.private_ip}/32"]
   }
 
   tags {
@@ -81,5 +81,3 @@ resource "aws_security_group" "bosh-ports" {
   }
 
 }
-
-

--- a/aws/firewall.tf
+++ b/aws/firewall.tf
@@ -114,7 +114,6 @@ resource "aws_security_group" "bosh_vm" {
     protocol  = "tcp"
     security_groups = [
       "${aws_security_group.bastion.id}",
-      "${aws_security_group.director.id}",
     ]
   }
 

--- a/aws/manifest.tf
+++ b/aws/manifest.tf
@@ -31,7 +31,6 @@ resource "template_file" "cf_manifest" {
         aws_subnet_id           = "${aws_subnet.bastion.0.id}"
         aws_availability_zone   = "${var.zones.zone0}"
         default_security_group  = "${aws_security_group.bosh_vm.name}"
-        nats_security_group     = "${aws_security_group.nats.name}"
     }
 
     provisioner "local-exec" {

--- a/aws/manifest.tf
+++ b/aws/manifest.tf
@@ -9,8 +9,9 @@ resource "template_file" "manifest" {
     filename = "${path.module}/manifest.yml.tpl"
 
     vars {
-        aws_static_ip           =  "${var.microbosh_IP}"
-        aws_subnet_id           =  "${aws_subnet.bastion.0.id}"
+        aws_static_ip           = "${var.microbosh_IP}"
+        aws_public_ip           = "${aws_eip.bosh.public_ip}"
+        aws_subnet_id           = "${aws_subnet.bastion.0.id}"
         aws_availability_zone   = "${var.zones.zone0}"
         aws_secret_access_key   = "${var.AWS_SECRET_ACCESS_KEY}"
         aws_access_key_id       = "${var.AWS_ACCESS_KEY_ID}"

--- a/aws/manifest.tf
+++ b/aws/manifest.tf
@@ -1,0 +1,34 @@
+# Terraform currently only has limited support for reading environment variables
+# Variables for use with terraform must be prefexed with 'TF_VAR_'
+# These two variables are passed in as environment variables named:
+# TF_VAR_AWS_ACCESS_KEY_ID and TF_VAR_AWS_SECRET_ACCESS_KEY respectively
+variable "AWS_ACCESS_KEY_ID" {}
+variable "AWS_SECRET_ACCESS_KEY" {}
+
+resource "template_file" "manifest" {
+    filename = "${path.module}/manifest.yml.tpl"
+
+    vars {
+        aws_static_ip           =  "${var.microbosh_IP}"
+        aws_subnet_id           =  "${aws_subnet.bastion.0.id}"
+        aws_availability_zone   = "${var.zones.zone0}"
+        aws_secret_access_key   = "${var.AWS_SECRET_ACCESS_KEY}"
+        aws_access_key_id       = "${var.AWS_ACCESS_KEY_ID}"
+        aws_region              = "${var.region}"
+        bosh_security_group     = "${aws_security_group.director.name}"
+        default_security_group  = "${aws_security_group.bosh_vm.name}"
+    }
+}
+
+resource "template_file" "cf_manifest" {
+    filename = "${path.module}/cf-manifest.yml.tpl"
+
+    vars {
+        aws_subnet_id           = "${aws_subnet.bastion.0.id}"
+        aws_availability_zone   = "${var.zones.zone0}"
+        default_security_group  = "${aws_security_group.bosh_vm.name}"
+        nats_security_group     = "${aws_security_group.nats.name}"
+    }
+}
+
+

--- a/aws/manifest.tf
+++ b/aws/manifest.tf
@@ -18,6 +18,10 @@ resource "template_file" "manifest" {
         bosh_security_group     = "${aws_security_group.director.name}"
         default_security_group  = "${aws_security_group.bosh_vm.name}"
     }
+
+    provisioner "local-exec" {
+      command = "echo '${template_file.manifest.rendered}' > manifest.yml"
+    }
 }
 
 resource "template_file" "cf_manifest" {
@@ -28,6 +32,10 @@ resource "template_file" "cf_manifest" {
         aws_availability_zone   = "${var.zones.zone0}"
         default_security_group  = "${aws_security_group.bosh_vm.name}"
         nats_security_group     = "${aws_security_group.nats.name}"
+    }
+
+    provisioner "local-exec" {
+      command = "echo '${template_file.cf_manifest.rendered}' > cf-manifest.yml"
     }
 }
 

--- a/aws/manifest.yml.tpl
+++ b/aws/manifest.yml.tpl
@@ -32,7 +32,9 @@ networks:
   - range: 10.0.0.0/24
     gateway: 10.0.0.1
     dns: [10.0.0.2]
-    cloud_properties: {subnet: ${aws_subnet_id}} # <--- Replace with Subnet ID
+    cloud_properties:
+      subnet: ${aws_subnet_id} # <--- Replace with Subnet ID
+      security_groups: [${bosh_security_group}]
 - name: public
   type: vip
 
@@ -107,7 +109,7 @@ jobs:
       access_key_id: ${aws_access_key_id} # <--- Replace with AWS Access Key ID
       secret_access_key: ${aws_secret_access_key} # <--- Replace with AWS Secret Key
       default_key_name: insecure-deployer
-      default_security_groups: [${bosh_security_group}]
+      default_security_groups: [${default_security_group}]
       region: ${aws_region}
 
     agent: {mbus: "nats://nats:nats-password@${aws_static_ip}:4222"}

--- a/aws/manifest.yml.tpl
+++ b/aws/manifest.yml.tpl
@@ -55,10 +55,8 @@ jobs:
 
   networks:
   - name: private
-    static_ips: [10.0.0.6]
+    static_ips: [${aws_static_ip}]
     default: [dns, gateway]
-  - name: public
-    static_ips: [${aws_static_ip}] # <--- Replace with Elastic IP
 
   properties:
     nats:
@@ -79,8 +77,8 @@ jobs:
       adapter: postgres
 
     registry:
-      address: 10.0.0.6
-      host: 10.0.0.6
+      address: ${aws_static_ip}
+      host: ${aws_static_ip}
       db: *db
       http: {user: admin, password: admin, port: 25777}
       username: admin
@@ -88,7 +86,7 @@ jobs:
       port: 25777
 
     blobstore:
-      address: 10.0.0.6
+      address: ${aws_static_ip}
       port: 25250
       provider: dav
       director: {user: director, password: director-password}
@@ -112,7 +110,7 @@ jobs:
       default_security_groups: [${bosh_security_group}]
       region: ${aws_region}
 
-    agent: {mbus: "nats://nats:nats-password@10.0.0.6:4222"}
+    agent: {mbus: "nats://nats:nats-password@${aws_static_ip}:4222"}
 
     ntp: &ntp [0.pool.ntp.org, 1.pool.ntp.org]
 
@@ -120,12 +118,12 @@ cloud_provider:
   template: {name: cpi, release: bosh-aws-cpi}
 
   ssh_tunnel:
-    host: ${aws_static_ip} # <--- Replace with your Elastic IP address
+    host: ${aws_static_ip}
     port: 22
     user: vcap
     private_key: .ssh/id_rsa # Path relative to this manifest file
 
-  mbus: "https://mbus:mbus-password@${aws_static_ip}:6868" # <--- Replace with Elastic IP
+  mbus: "https://mbus:mbus-password@${aws_static_ip}:6868"
 
   properties:
     aws: *aws

--- a/aws/manifest.yml.tpl
+++ b/aws/manifest.yml.tpl
@@ -59,6 +59,8 @@ jobs:
   - name: private
     static_ips: [${aws_static_ip}]
     default: [dns, gateway]
+  - name: public
+    static_ips: [${aws_public_ip}]
 
   properties:
     nats:

--- a/aws/manifest.yml.tpl
+++ b/aws/manifest.yml.tpl
@@ -16,7 +16,7 @@ resource_pools:
     url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3012
     sha1: 3380b55948abe4c437dee97f67d2d8df4eec3fc1
   cloud_properties:
-    instance_type: m3.xlarge
+    instance_type: t2.medium
     ephemeral_disk: {size: 25_000, type: gp2}
     availability_zone: ${aws_availability_zone} # <--- Replace with Availability Zone
 

--- a/aws/network.tf
+++ b/aws/network.tf
@@ -1,7 +1,3 @@
-resource "aws_eip" "bosh" {
-  vpc = true
-}
-
 resource "aws_internet_gateway" "default" {
   vpc_id = "${aws_vpc.default.id}"
 }

--- a/aws/network.tf
+++ b/aws/network.tf
@@ -14,7 +14,7 @@ resource "aws_subnet" "bastion" {
   }
 }
 
-resource "aws_route_table" "bastion" {
+resource "aws_route_table" "internet" {
   vpc_id = "${aws_vpc.default.id}"
   route {
     cidr_block = "0.0.0.0/0"
@@ -25,5 +25,5 @@ resource "aws_route_table" "bastion" {
 resource "aws_route_table_association" "bastion" {
   count = 1
   subnet_id = "${element(aws_subnet.bastion.*.id, count.index)}"
-  route_table_id = "${aws_route_table.bastion.id}"
+  route_table_id = "${aws_route_table.internet.id}"
 }

--- a/aws/network.tf
+++ b/aws/network.tf
@@ -1,3 +1,7 @@
+resource "aws_eip" "bosh" {
+  vpc = true
+}
+
 resource "aws_internet_gateway" "default" {
   vpc_id = "${aws_vpc.default.id}"
 }

--- a/aws/network.tf
+++ b/aws/network.tf
@@ -27,3 +27,21 @@ resource "aws_route_table_association" "bastion" {
   subnet_id = "${element(aws_subnet.bastion.*.id, count.index)}"
   route_table_id = "${aws_route_table.internet.id}"
 }
+
+resource "aws_subnet" "cf_core" {
+  count             = 1
+  vpc_id            = "${aws_vpc.default.id}"
+  cidr_block        = "${lookup(var.cf_cidr, concat("zone", count.index))}"
+  availability_zone = "${lookup(var.zones, concat("zone", count.index))}"
+  map_public_ip_on_launch = true
+  depends_on = ["aws_internet_gateway.default"]
+  tags {
+    Name = "${var.env}-cf_core-subnet-${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "cf_core" {
+  count = 1
+  subnet_id = "${element(aws_subnet.cf_core.*.id, count.index)}"
+  route_table_id = "${aws_route_table.internet.id}"
+}

--- a/aws/network.tf
+++ b/aws/network.tf
@@ -26,21 +26,3 @@ resource "aws_route_table_association" "bastion" {
   subnet_id = "${element(aws_subnet.bastion.*.id, count.index)}"
   route_table_id = "${aws_route_table.internet.id}"
 }
-
-resource "aws_subnet" "cf_core" {
-  count             = 1
-  vpc_id            = "${aws_vpc.default.id}"
-  cidr_block        = "${lookup(var.cf_cidr, concat("zone", count.index))}"
-  availability_zone = "${lookup(var.zones, concat("zone", count.index))}"
-  map_public_ip_on_launch = true
-  depends_on = ["aws_internet_gateway.default"]
-  tags {
-    Name = "${var.env}-cf_core-subnet-${count.index}"
-  }
-}
-
-resource "aws_route_table_association" "cf_core" {
-  count = 1
-  subnet_id = "${element(aws_subnet.cf_core.*.id, count.index)}"
-  route_table_id = "${aws_route_table.internet.id}"
-}

--- a/aws/network.tf
+++ b/aws/network.tf
@@ -7,7 +7,6 @@ resource "aws_subnet" "bastion" {
   vpc_id            = "${aws_vpc.default.id}"
   cidr_block        = "${lookup(var.public_cidrs, concat("zone", count.index))}"
   availability_zone = "${lookup(var.zones, concat("zone", count.index))}"
-  map_public_ip_on_launch = true
   depends_on = ["aws_internet_gateway.default"]
   tags {
     Name = "${var.env}-bastion-subnet-${count.index}"

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,7 +1,3 @@
 output "bastion_ip" {
   value = "${aws_instance.bastion.public_ip}"
 }
-
-output "bosh_ip" {
-	value = "${aws_eip.bosh.public_ip}"
-}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,3 +1,7 @@
 output "bastion_ip" {
   value = "${aws_instance.bastion.public_ip}"
 }
+
+output "bosh_ip" {
+       value = "${aws_eip.bosh.public_ip}"
+}

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -67,5 +67,8 @@ cd cf-release
 git checkout v215
 ./update
 time bosh upload release releases/cf-215.yml
-bosh deployment ../cf-manifest.yml
+# Run deployment
+cd ~
+sed -i "s/BOSH_UUID/$(bosh status --uuid)/" cf-manifest.yml
+bosh deployment cf-manifest.yml
 time bosh deploy

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
+STEMCELL=bosh-stemcell-3056-aws-xen-ubuntu-trusty-go_agent.tgz
 
 # Prepare the jumpbox to be able to install ruby and git-based bosh and cf repos
-cd $HOME
-
 sudo apt-get update
-sudo apt-get install -y build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
+sudo apt-get install -y build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3 dstat
 
 # Set correct permissions for the ssh key we copied
+# TF feature request: https://github.com/hashicorp/terraform/issues/3071
 chmod 400 ~/.ssh/id_rsa
 chmod 400 ~/.ssh/id_rsa.pub
 
@@ -14,6 +14,35 @@ chmod 400 ~/.ssh/id_rsa.pub
 eval `ssh-agent`
 ssh-add ~/.ssh/id_rsa
 
+# TODO: download bosh-init from our own bucket
 wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64 -O bosh-init
 chmod +x bosh-init
-./bosh-init deploy manifest_aws.yml
+export BOSH_INIT_LOG_LEVEL=debug
+export BOSH_INIT_LOG_PATH=bosh_init.log
+time ./bosh-init deploy manifest_aws.yml
+
+# TODO: install bosh cli rubygems in parallel to bosh-init (which mainly stresses bosh server)
+echo "Installing bosh cli..."
+time sudo gem install bosh_cli -v 1.3056.0 --no-ri --no-rdoc
+export PATH=$PATH:/usr/local/bin/bosh
+
+# FIXME: make passwords properly strong
+# FIXME: bosh for some reason ignores name and sets it to "my-bosh"
+# FIXME: cmd below works, but bosh compains 'stty: standard input: Inappropriate ioctl for device'
+echo -e "admin\nadmin" | bosh target 10.0.0.6 "IamIgnored"
+
+# TODO: download stemcell from our own bucket using multiple threads, in paralell with other tasks
+time bosh download public stemcell $STEMCELL
+time bosh upload stemcell $STEMCELL
+
+# TODO: this can also happen in parallel
+time git clone https://github.com/cloudfoundry/cf-release.git -b v215
+
+# TODO: pre-seed bosh cache, otherwise action below takes forever...
+# FIXME: make output from bosh command stream and have color. It takes quite some time to complete, immediate output is desirable.
+# (this script is run via ssh from makefile)
+
+# No, you can't bosh upload release cf-release/releases/cf-215.yml, you have to CD into the cf-release first
+echo "Uploading v215 release to bosh..."
+cd cf-release
+time bosh upload release releases/cf-215.yml

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -66,4 +66,4 @@ time bosh upload release releases/cf-215.yml
 cd ~
 sed -i "s/BOSH_UUID/$(bosh status --uuid)/" cf-manifest.yml
 bosh deployment cf-manifest.yml
-time bosh deploy
+time bosh -n deploy

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -60,3 +60,5 @@ cd cf-release
 git checkout v215
 ./update
 time bosh upload release releases/cf-215.yml
+bosh deployment ../cf-manifest.yml
+time bosh deploy

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-STEMCELL=bosh-stemcell-3056-aws-xen-ubuntu-trusty-go_agent.tgz
-VM_STEMCELL=light-bosh-stemcell-3063-aws-xen-hvm-ubuntu-trusty-go_agent.tgz
+STEMCELL=light-bosh-stemcell-3063-aws-xen-hvm-ubuntu-trusty-go_agent.tgz
 
 PACKAGES="build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3 dstat"
 if ! dpkg -l $PACKAGES > /dev/null 2>&1; then
@@ -46,11 +45,7 @@ echo -e "admin\nadmin" | bosh target 10.0.0.6 "IamIgnored"
 if [ ! -f $STEMCELL ]; then
   time bosh download public stemcell $STEMCELL
 fi
-if [ ! -f $VM_STEMCELL ]; then
-  time bosh download public stemcell $VM_STEMCELL
-fi
 time bosh upload stemcell $STEMCELL --skip-if-exists
-time bosh upload stemcell $VM_STEMCELL --skip-if-exists
 
 # TODO: this can also happen in parallel
 if [ ! -d cf-release ]; then

--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 STEMCELL=bosh-stemcell-3056-aws-xen-ubuntu-trusty-go_agent.tgz
 
-# Prepare the jumpbox to be able to install ruby and git-based bosh and cf repos
-sudo apt-get update
-sudo apt-get install -y build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3 dstat
+PACKAGES="build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3 dstat"
+if ! dpkg -l $PACKAGES > /dev/null 2>&1; then
+	# Prepare the jumpbox to be able to install ruby and git-based bosh and cf repos
+  sudo apt-get update
+	sudo apt-get install -y $PACKAGES
+fi
 
 # Set correct permissions for the ssh key we copied
 # TF feature request: https://github.com/hashicorp/terraform/issues/3071
@@ -22,8 +25,13 @@ export BOSH_INIT_LOG_PATH=bosh_init.log
 time ./bosh-init deploy manifest_aws.yml
 
 # TODO: install bosh cli rubygems in parallel to bosh-init (which mainly stresses bosh server)
-echo "Installing bosh cli..."
-time sudo gem install bosh_cli -v 1.3056.0 --no-ri --no-rdoc
+if gem list | grep -q bosh_cli; then
+  echo "Bosh cli already installed, skipping..."
+else
+  echo "Installing bosh cli..."
+  time sudo gem install bosh_cli -v 1.3056.0 --no-ri --no-rdoc
+fi
+
 export PATH=$PATH:/usr/local/bin/bosh
 
 # FIXME: make passwords properly strong
@@ -32,11 +40,15 @@ export PATH=$PATH:/usr/local/bin/bosh
 echo -e "admin\nadmin" | bosh target 10.0.0.6 "IamIgnored"
 
 # TODO: download stemcell from our own bucket using multiple threads, in paralell with other tasks
-time bosh download public stemcell $STEMCELL
-time bosh upload stemcell $STEMCELL
+if [ ! -f $STEMCELL ]; then
+  time bosh download public stemcell $STEMCELL
+fi
+time bosh upload stemcell $STEMCELL --skip-if-exists
 
 # TODO: this can also happen in parallel
-time git clone https://github.com/cloudfoundry/cf-release.git -b v215
+if [ ! -d cf-release ]; then
+  time git clone https://github.com/cloudfoundry/cf-release.git
+fi
 
 # TODO: pre-seed bosh cache, otherwise action below takes forever...
 # FIXME: make output from bosh command stream and have color. It takes quite some time to complete, immediate output is desirable.
@@ -45,4 +57,6 @@ time git clone https://github.com/cloudfoundry/cf-release.git -b v215
 # No, you can't bosh upload release cf-release/releases/cf-215.yml, you have to CD into the cf-release first
 echo "Uploading v215 release to bosh..."
 cd cf-release
+git checkout v215
+./update
 time bosh upload release releases/cf-215.yml

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -22,6 +22,22 @@ variable "public_cidrs" {
   }
 }
 
+variable "cf_cidr" {
+  description = "CIDRs for cloud foundry core components"
+  default     = {
+    zone0 = "10.0.1.0/24"
+    zone1 = "10.0.2.0/24"
+  }
+}
+
+variable "apps_cidr" {
+  description = "CIDRs for components used by apps: DEAs and routers"
+  default     = {
+    zone0 = "10.0.11.0/24"
+    zone1 = "10.0.12.0/24"
+  }
+}
+
 variable "amis" {
   description = "Base AMI to launch the instances with"
   default = {

--- a/globals.tf
+++ b/globals.tf
@@ -8,6 +8,11 @@ variable "office_cidrs" {
 }
 
 variable "ssh_user" {
-	description = "Username used to ssh into VMs."
-	default     = "ubuntu"
+  description = "Username used to ssh into VMs."
+  default     = "ubuntu"
+}
+
+variable "microbosh_IP" {
+  description = "microbosh internal IP. Do not change. This is more of a constant than variable."
+  default     = "10.0.0.6"
 }


### PR DESCRIPTION
[Create NATS instance in CF environment on AWS](https://www.pivotaltracker.com/n/projects/1275640/stories/101129996)

> Note: This PR is a continuation of #3, which was closed, and it includes additional changes from that (closed) PR. 
> The most important changes:
> - stop using EIP for microbosh (unnecessary)
> - adjust instances (disk sizes, instance types)
> - ~~create subnet for NATS~~ (not used at the end)

Using the existing microbosh and bastion host deployed using terraform and bosh-init, this story extends the CF landscape to include define the first steps and manifests to deploy the NATS component. 

We agreed to build out the CF landscape one component at a time and this is the first of these stories. 

Initially the story was meant for GCE+AWS, but it got split and we will focus only on AWS.

**Acceptance Criteria**
**Given** that there is a script for deploying a CF build in AWS
**When** I run the script 
**Then** an instance of NATS is deployed in the environment
## Scope of the PR

This story should be reviewed in this context
- I want to have a initial basic CF manifest which includes:
  - a job to deploy the nats service
  - all the required elements: pools, compile pools, network definitions, etc.
- I want to be able to upload the manifest on the existing microbosh.
- I want to be able to do a `bosh deployment` and have a running instance of nats.
- ~~I want to have the necessary security groups that allow everything to work.~~

> Note: We discarded implement security groups due limitations on BOSH CPI. see git comments.
## How to review the card.

We carry on implementing tasks on `Makefile` to deploy the environment. To provision the environment simply run:

```
make aws DEPLOY_ENV=<name>
```

If it finishes successfully, you can try to connect to nats with the nats client from the bastion host

```
# Install nats client
sudo gem install nats --no-ri --no-rdoc

# Listen for nats messages in background
nats-sub '>' -s nats://nats:nats-password@10.0.0.10:4222 & 

# Send a message
nats-pub foo 'Hello World!' -s nats://nats:nats-password@10.0.0.10:4222 
```
## Detailed PR description

The detailed execution of the deployment will be:
- `apply-aws`: Apply terraform to create all the AWS required elements, including:
  - networks and security groups.
  - create the bastion host
  - Render the templated manifests. We use a local provisioner to create a local file and we upload it via SSH. 
- `prepare-provision`: Upload the manifests to the bastion
- `provision`: Run the script `provision.sh` which will deploy microbosh and CF:
  1. Deploy microbosh using `bosh-init`
  2. Deploy CF (and nats) using `bosh deploy`

The manifest file is based on [this example manifest from `cf-release`](https://github.com/cloudfoundry/cf-release/blob/master/example_manifests/minimal-aws.yml).
