### PR TITLE
Update GCE resurrector password for director

### DIFF
--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -120,7 +120,7 @@ jobs:
           password: hm
         director_account:
           user: admin
-          password: admin123
+          password: admin
         resurrector_enabled: true
 
       ntp: &ntp


### PR DESCRIPTION
## What

Current director password is different than the one setup in the director, causing it to fail to get the current desired state.

This is a minor change which we will put in the scope of the card [#102465348 Create a CF instance in GCE](https://www.pivotaltracker.com/story/show/102465348)
## How to reproduce
1. Provision a GCE microbosh instance
2. Login on the microbosh node (`ssh <bosh_ip> -l ubuntu -i ssh/insecure-deployer`) and check the healthcheck logs (`sudo less  /var/vcap/sys/log/health_monitor/health_monitor.log`). It fails with: 

```
E, [2015-09-07T12:39:26.957806 #1467] ERROR : Cannot get deployments from director at https://127.0.0.1:25555/deployments: 401 Not authorized: '/deployments'
...
W, [2015-09-07T12:39:26.958136 #1467]  WARN : (Resurrector) event did not have deployment, job and index: Alert @ 2015-09-07 12:39:26 UTC, severity 3: Cannot get deployments from director at https://127.0.0.1:25555/deployments: 401 Not authorized: '/deployments'
```
## How to check this patch

Get a running environment (you can also apply the new manifest with `bosh-init apply manifest.yml`.

After that, hm authentication will work. 

You can try resurrector by deleting any VM. Get the list of VMs with:

```
 bosh vms --details
Acting as user 'admin' on 'micro-google'
Deployment `hector'

Director task 13

Task 13 done

+-----------+---------+---------------+---------------+-----------------------------------------+--------------------------------------+--------------+
| Job/index | State   | Resource Pool | IPs           | CID                                     | Agent ID                             | Resurrection |
+-----------+---------+---------------+---------------+-----------------------------------------+--------------------------------------+--------------+
| api/0     | running | common        | 10.0.0.151    | vm-a476a1ad-b631-405f-6260-8e978d5a1aa1 | f416dda4-2adb-4cf7-a1ca-75141096458b | active       |
| core/0    | running | common        | 10.0.0.180    | vm-062be8b9-c62c-4a8e-7568-d05bc0f9ac38 | e7f6f694-354d-47a6-ab2c-6fe2b9b2117c | active       |
| data/0    | running | common        | 10.0.0.17     | vm-ead74fab-23da-4eea-49db-b3cbc7e0b843 | 23022d57-d417-4a6d-aae4-4b5194e7a370 | active       |
| haproxy/0 | running | large         | 10.0.0.159    | vm-648f486f-70de-4b78-4467-32f3e9761538 | 90772aec-8517-4ed6-b8be-cdeb170fbd38 | active       |
|           |         |               | 100.200.200.100 |                                         |                                      |              |
| runner/0  | running | large         | 10.0.0.210    | vm-3fde039b-dd76-4d3b-71ce-5fb032c27abf | 1e13f660-9dab-438d-8c0e-8f451885e401 | active       |
| runner/1  | running | large         | 10.0.0.197    | vm-9fe38969-dcd1-4d4d-50c4-e5db30666667 | 30409f34-4b59-4bf6-984f-7ee0d1d32774 | active       |
| runner/2  | running | large         | 10.0.0.146    | vm-c4223821-6136-40f3-598a-9d2c561752d7 | d4cc66f1-e237-4a6a-a9a1-fd72da4c0eaf | active       |
+-----------+---------+---------------+---------------+-----------------------------------------+--------------------------------------+--------------+

```

The resurrector log should report the missing VM:

```
I, [2015-09-07T11:37:32.962868 #8144]  INFO : [ALERT] Alert @ 2015-09-07 11:37:32 UTC, severity 2: e60829d0-1ea3-48d2-9049-0235f8b1e99c has timed out
W, [2015-09-07T11:37:32.978944 #8144]  WARN : (Resurrector) notifying director to recreate unresponsive VM: hector runner/2
...
I, [2015-09-07T12:42:03.048622 #8144]  INFO : Adding agent d4cc66f1-e237-4a6a-a9a1-fd72da4c0eaf (runner/2) to hector...
...
I, [2015-09-07T11:40:07.864301 #8144]  INFO : [ALERT] Alert @ 2015-09-07 11:40:07 UTC, severity 1: process is not running
W, [2015-09-07T11:40:07.864399 #8144]  WARN : (Resurrector) event did not have deployment, job and index: Alert @ 2015-09-07 11:40:07 UTC, severity 1: process is not running
...
```
## Who can review this

Anyone but @keymon 
