### PR TITLE
[#102582832 Securely deploy CF to GCE]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,11 @@ provision: check-env-vars
 	@ssh -t -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash provision.sh $(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bosh_ip)'
 
 bosh-delete-aws: set-aws bosh-delete
-bosh-delete-gce: set-gce bosh-delete
+bosh-delete-gce: set-gce bosh-delete delete-route-gce
 bosh-delete:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) './bosh-init delete manifest_${dir}.yml'
+delete-route-gce:
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash ./delete-route.sh'
 
 destroy-aws: set-aws destroy
 destroy-gce: set-gce destroy

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -1,6 +1,6 @@
 resource "google_compute_instance" "bastion" {
   name = "${var.env}-cf-bastion"
-  depends_on = [ "template_file.manifest", "template_file.cf-manifest" ]
+  depends_on = [ "template_file.manifest", "template_file.cf-manifest", "google_compute_firewall.ssh" ]
   machine_type = "n1-standard-1"
   zone = "${element(split(",", var.gce_zones), count.index)}"
   disk {

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -36,4 +36,9 @@ resource "google_compute_instance" "bastion" {
           destination = "/home/ubuntu/account.json"
   }
 
+  provisioner "file" {
+          source = "${path.module}/delete-route.sh"
+          destination = "/home/ubuntu/delete-route.sh"
+  }
+
 }

--- a/gce/cf210-manifest.yml.erb
+++ b/gce/cf210-manifest.yml.erb
@@ -61,7 +61,7 @@ resource_pools:
       name: bosh-google-kvm-ubuntu-trusty-go_agent
       version: latest
     cloud_properties:
-      machine_type:  n1-highmem-8
+      machine_type:  n1-highmem-2
       root_disk_size_gb: 40
       root_disk_type: pd-standard
 
@@ -144,7 +144,7 @@ jobs:
       - name: dea_next
       - name: dea_logging_agent
       - name: metron_agent
-    instances: 3
+    instances: 2
     resource_pool: large
     networks:
       - name: default

--- a/gce/cf210-manifest.yml.erb
+++ b/gce/cf210-manifest.yml.erb
@@ -41,6 +41,16 @@ networks:
         - bosh
         - <%= deployment_name %>
 
+  - name: haproxy
+    type: dynamic
+    cloud_properties:
+      network_name: <%= network_name %>
+      ephemeral_external_ip: true
+      tags:
+        - haproxy
+        - bosh
+        - <%= deployment_name %>
+
   - name: static
     type: vip
 
@@ -85,7 +95,7 @@ jobs:
     instances: 1
     resource_pool: large
     networks:
-      - name: default
+      - name: haproxy
         default: [dns, gateway]
       - name: static
         static_ips:

--- a/gce/delete-route.sh
+++ b/gce/delete-route.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+DEPLOYMENT_NAME=`python -c 'import yaml; print yaml.load(file("cf-manifest.yml"))["name"]'`
+
+# Returns the $2 field from $1 file, with $3 extra syntax
+json_get(){
+  value=`python -c "import json; print json.load(file(\"$1\"))[\"$2\"]$3"`
+  if [[ $? != 0 ]] ; then
+    echo "Error retrieving $2 from $1"
+    exit 100
+  else
+    echo "$value"
+  fi
+}
+
+# Login to GCE
+export CLOUDSDK_PYTHON_SITEPACKAGES=1
+ACCOUNT=`json_get account.json client_email`
+json_get account.json private_key > gce.key && chmod 600 gce.key
+gcloud auth activate-service-account $ACCOUNT --key-file gce.key
+
+echo "Attempting to delete $DEPLOYMENT_NAME-internalbosh route..."
+gcloud compute routes delete -q $DEPLOYMENT_NAME-internalbosh

--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -31,6 +31,7 @@ networks:
     type: dynamic
     cloud_properties:
       network_name: ${gce_microbosh_net}
+      ip_forwarding: true
       tags:
         - bosh
         - bastion

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -11,8 +11,7 @@ if ! dpkg -l $PACKAGES > /dev/null 2>&1; then
 fi
 
 # Set correct permissions for the ssh key we copied, as TF can't do that yet
-chmod 400 ~/.ssh/id_rsa
-chmod 400 ~/.ssh/id_rsa.pub
+chmod 400 ~/.ssh/id_rsa ~/.ssh/id_rsa.pub ~/account.json
 
 # start the ssh-agent and add the keys
 eval `ssh-agent`

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -2,6 +2,19 @@
 STEMCELL=light-bosh-stemcell-2968-google-kvm-ubuntu-trusty-go_agent.tgz
 RELEASE=210
 BOSH_EXTERNAL_IP=$1
+MICROBOSH_ZONE=europe-west1-b
+DEPLOYMENT_NAME=`python -c 'import yaml; print yaml.load(file("cf-manifest.yml"))["name"]'`
+
+# Returns the $2 field from $1 file, with $3 extra syntax
+json_get(){
+  value=`python -c "import json; print json.load(file(\"$1\"))[\"$2\"]$3"`
+  if [[ $? != 0 ]] ; then
+    echo "Error retrieving $2 from $1"
+    exit 100
+  else
+    echo "$value"
+  fi
+}
 
 # Prepare the jumpbox to be able to install ruby and git-based bosh and cf repos
 PACKAGES="build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3 dstat"
@@ -22,6 +35,16 @@ tr -d '\n' < account.json > account_tmp.json
 python -c 'print open("manifest_gce.yml").read().replace("ACCOUNT_JSON", open("account_tmp.json").read()).rstrip().rstrip("EOF")' > microbosh-manifest.yml 2>&1
 rm account_tmp.json manifest_gce.yml
 
+# Login to GCE
+export CLOUDSDK_PYTHON_SITEPACKAGES=1
+ACCOUNT=`json_get account.json client_email`
+json_get account.json private_key > gce.key && chmod 600 gce.key
+gcloud auth activate-service-account $ACCOUNT --key-file gce.key
+
+# TODO: Add logic that checks if bosh-init really does re-create mBosh VM and only remove the route then
+echo "Attempting to delete $DEPLOYMENT_NAME-internalbosh route..."
+gcloud compute routes delete -q $DEPLOYMENT_NAME-internalbosh
+
 # Deploy microbosh server
 if [ ! -x bosh-init ]; then
   wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64 -O bosh-init
@@ -30,6 +53,64 @@ fi
 export BOSH_INIT_LOG_LEVEL=debug
 export BOSH_INIT_LOG_PATH=bosh-init.log
 time ./bosh-init deploy microbosh-manifest.yml
+
+# Configure internal routing for microbosh
+# 1. Get microbosh IP
+BOSH_VM=`json_get microbosh-manifest-state.json current_vm_cid`
+gcloud compute instances describe --zone $MICROBOSH_ZONE --format json $BOSH_VM > microbosh-info.json
+BOSH_INTERNAL_IP=`json_get microbosh-info.json networkInterfaces '[0]["networkIP"]'`
+
+# 2. Configure iptables on microbosh server
+echo "Configuring IPtables on the microbosh..."
+RULE="-d $BOSH_EXTERNAL_IP/32 -j DNAT --to-destination $BOSH_INTERNAL_IP"
+ssh -T -oStrictHostKeyChecking=no $BOSH_INTERNAL_IP <<EOF
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
+for CHAIN in PREROUTING OUTPUT ; do
+  echo "Checking \$CHAIN $RULE"
+  sudo iptables -t nat -C \$CHAIN $RULE || sudo iptables -t nat -A \$CHAIN $RULE
+done
+sudo service iptables-persistent save
+EOF
+
+# 3. Re-route BOSH_EXTERNAL_IP internally. Check if route exists and is correct first.
+CREATE=false
+UPDATE=false
+gcloud compute routes describe $DEPLOYMENT_NAME-internalbosh --format json >internalbosh-route.json 2>route.errors
+if [[ $? != 0 ]] ; then
+  grep -q "The resource 'projects/.\+/routes/${DEPLOYMENT_NAME}-internalbosh' was not found" route.errors
+  if [[ $? == 0 ]] ; then
+    CREATE=true
+  else
+    echo "Failed retrieving ${DEPLOYMENT_NAME}-internalbosh route information, aborting. Errors:"
+    cat route.errors
+    exit 255
+  fi
+else
+  # Compare if any of the route attributes need updating
+  destRange=`json_get internalbosh-route.json destRange`
+   priority=`json_get internalbosh-route.json priority`
+    network=`json_get internalbosh-route.json network '.split("/")[-1]'`
+  routedest=`json_get internalbosh-route.json nextHopInstance '.split("/")[-1]'`
+
+  [[ "$destRange" != "$BOSH_EXTERNAL_IP/32" ]] && UPDATE=true
+  [[ "$priority"  != "1" ]] && UPDATE=true
+  [[ "$network"   != "$DEPLOYMENT_NAME-cf-bastion" ]] && UPDATE=true
+  [[ "$routedest" != "$BOSH_VM" ]] && UPDATE=true
+
+  # In GCE, you can't update routes, you have to delete and create new
+  if $UPDATE ; then
+    echo "Route needs updating, deleting..."
+    gcloud compute routes delete -q $DEPLOYMENT_NAME-internalbosh
+    [[ $? != 0 ]] && echo "Need to update the route, but failed to delete, aborting" && exit 102
+    CREATE=true
+  fi
+fi
+
+if $CREATE ; then
+  echo "Creating $DEPLOYMENT_NAME-internalbosh route..."
+  gcloud compute routes create $DEPLOYMENT_NAME-internalbosh --network $DEPLOYMENT_NAME-cf-bastion --destination-range "$BOSH_EXTERNAL_IP/32" --next-hop-instance $BOSH_VM --next-hop-instance-zone $MICROBOSH_ZONE --priority 1 --description Route_packets_for_bosh_external_IP_directly_to_the_microbosh_instance_via_internal_network
+  [[ $? != 0 ]] && echo "Failed creating route, aborting" && exit 103
+fi
 
 # Install BOSH CLI and log in
 if gem list | grep -q bosh_cli; then

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 STEMCELL=light-bosh-stemcell-2968-google-kvm-ubuntu-trusty-go_agent.tgz
 RELEASE=210
-BOSH_IP=$1
+BOSH_EXTERNAL_IP=$1
 
 # Prepare the jumpbox to be able to install ruby and git-based bosh and cf repos
 PACKAGES="build-essential git zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3 dstat"
@@ -39,7 +39,7 @@ else
 fi
 
 export PATH=$PATH:/usr/local/bin/bosh
-echo -e "admin\nadmin" | bosh target $BOSH_IP
+echo -e "admin\nadmin" | bosh target $BOSH_EXTERNAL_IP
 
 if [ ! -f $STEMCELL ]; then
   wget http://storage.googleapis.com/bosh-stemcells/$STEMCELL


### PR DESCRIPTION
The current GCE deploy relies on the firewalls being opened up. This is because of constraints that GCE places on how we can define the network. 
​
It is clearly not acceptable to have a BOSH installation that is open to the internet. The objective of this story is to enable us to deploy CF to GCE in a secure way.
​
# What

The problem is BOSH on GCE requires a fixed external IP (GCE doesn't support fixed internal IP). Since the components are created by BOSH we don't know them in advance so we must open the external IP to the whole world.
​
The idea here is to make that all calls to the external IP are routed internally instead and close the firewall. To do this we need the following changes:
​
- Strict firewall rules to prevent open access
- Creating a new `haproxy` logical network in the manifest that adds the tag `haproxy` on each of its instances. This allows to tighten the firewall rules.
- A GCE network route that routes internally to the BOSH instance all packets destined to the BOSH external IP. This is done via `gcloud` command in the `provision.sh` script after BOSH VM is created, and before cloud foundry is deployed
- 1 `iptables` rule in the `PREROUTING` table on the BOSH instance. We need it because the BOSH instance doesn't have the external IP attached to its local interface, so if we send packets to it with the external IP as destination, they get dropped. The rule changes the destination to the internal IP when they are received, before they get processed.
- 1 `iptables` rule in the `OUTPUT` table on the BOSH instance. This is to allow BOSH to connect to itself. Without it there is conflict with GCE routing and the packets get lost. The rule changes the destination to the internal IP before they are supposed to be sent out. They are now processed directly without going out to the network.
- Delete route at the beginning of `provision.sh` script. If we don't do this, should `bosh-init` require to recreate the BOSH instance, the packets will be sent to the old BOSH that was deleted and they get lost. Because of that `bosh-init` will fail to recreate BOSH.
- Logic in `provision.sh` script to check integrity of the existing network route. This is not currently useful because we always delete the route at the beginning, but this would become useful should we implement better logic (see _Notes_)
  ​
  # How to review
- Create a new cloud foundry environment:
  ​

```
make gce DEPLOY_ENV=<new environment>
```
- Make sure it works fine by deploying an application to cloud foundry
- Test that ports `22, 80, 443, 4222, 6868, 25250, 25555, 25777` are not open anymore for all bosh and cloud foundry instances to the world

​
# Notes
- The temporary deletion of the route disables internal access to BOSH. The impact should be evaluated in another story. There are probably better solutions, like monitoring the BOSH state file for VM change
- For some reason order of the commits in this PR is different that in my git log, they should be reviewed in this order:

```
3251410 GCE: use less resources
e1b558b GCE provision: refactor BOSH_IP
fb15745 GCE provision: tighten credentials security
5c2449a GCE provision: comments and whitespace
2eb8e8a GCE provision: handle route creation
dd83cb2 GCE microbosh: enable IP forwarding
950dec0 GCE cf: tag haproxy instance
7e1541e GCE firewall: only internal access to microbosh
32fa7ee GCE destroy: Delete the microbosh route
```
