### PR TITLE
Update the gce manifest template formatting

### DIFF
--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -60,7 +60,7 @@ jobs:
       - name: private
         default: [dns, gateway]
       - name: public
-        static_ips: ${gce_static_ip}
+        static_ips: [ ${gce_static_ip} ]
 
     properties:
       nats:

--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -115,7 +115,7 @@ jobs:
         recursor: 8.8.8.8
 
       agent:
-        mbus: nats://nats:nats@${gce_static_ip}:4222
+        mbus: nats://nats:nats-password@${gce_static_ip}:4222
         ntp: *ntp
         blobstore:
            options:


### PR DESCRIPTION
This brings the gce manifest template formatting in line with the aws
manifest template.

Minor changes other than formatting/reordering ported from the aws template:
- The passwords have been changed to match aws ("thing-password" rather
  than "thing")
- max_threads has been specified on the director

Things I have not ported:
- The aws registry configuration is substantially larger, enabling the
  HTTP interface and configuring the database. I suspect this needs
  pulling in too.
