### PR TITLE
[#102890358] Get logging working on CF GCE

### DIFF
--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -12,9 +12,9 @@ resource "google_compute_firewall" "ssh" {
   }
 }
 
-
-
-# TODO: restrict this better, opening to ports 4222, 6868, 25250, 25555, 25777 is not enough
+# TODO: restrict better, currently opening all for convenience; known ports that need to be open:
+# TCP: 4222, 6868, 25250, 25555, 25777
+# UDP: 52, 3457
 resource "google_compute_firewall" "internal" {
   name = "${var.env}-cf-internal"
   description = "Open internal communication between instances"
@@ -30,7 +30,6 @@ resource "google_compute_firewall" "internal" {
   }
   allow {
     protocol = "udp"
-    ports = [ 53 ]
   }
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/102890358

Even though you could get logs from API and RTR, there were no app logs appearing when you did `cf logs myapp`. This was found out to be due blocked UDP port 3457. CF logging system is designed to be lossy, however TCP support is [not completely off the table](http://www.activestate.com/blog/2015/03/loggregator-voice-cloud-foundry). For now the fix is to open UDP port 3457. Instead of fixing this single firewall related issue, 

Opening GCE firewall for internal communication for all to all traffic on UDP and TCP. Reason is that we're finding one-by-one various CF functionalities disabled by firewall restrictions. It's always a tedious process to find out which ports exactly need to be open. Opening all-to-all now, so that we have a fully functional platform. We'll be restricting ports later, possibly also using different tags for different host. Keeping list of known ports to be open in the tf file comments.

_Tesing_

Deploy an app that creates logs (e.g. sping-music). Click around. Follow logs using cf-logs. You should see logs from the app (in addition to router and api logs).

_Reviewing_
Not @mtekel
