### PR TITLE
[#102832380] Automatically destroy CF environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,12 @@ delete-deployment:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) \
 	    'for deployment in $$(bosh deployments | cut -f 2 -d "|" | grep -v -e ^+- -e ^$$ -e "total:" -e "Name") ; do bosh -n delete deployment $$deployment --force ; done'
 
+delete-release-aws: set-aws delete-release
+delete-release-gce: set-gce delete-release
+delete-release:
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) \
+	    'for release in $$(bosh releases | grep "|" | cut -f 2 -d "|" | grep -v -e "Name") ; do bosh -n delete release $$release --force ; done'
+
 delete-route-gce:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash ./delete-route.sh'
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: all apply provision destroy ssh
+SHELL := /bin/bash
 
 all:
 	$(error Usage: make <aws|gce> DEPLOY_ENV=name)

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ bosh-delete-aws: set-aws bosh-delete
 bosh-delete-gce: set-gce bosh-delete delete-route-gce
 bosh-delete:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) './bosh-init delete manifest_${dir}.yml'
+delete-deployment-aws: set-aws delete-deployment
+delete-deployment-gce: set-gce delete-deployment
+delete-deployment:
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) \
+	    'for deployment in $$(bosh deployments | cut -f 2 -d "|" | grep -v -e ^+- -e ^$$ -e "total:" -e "Name") ; do bosh -n delete deployment $$deployment --force ; done'
+
 delete-route-gce:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash ./delete-route.sh'
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ delete-release:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) \
 	    'for release in $$(bosh releases | grep "|" | cut -f 2 -d "|" | grep -v -e "Name") ; do bosh -n delete release $$release --force ; done'
 
+delete-stemcell-aws: set-aws delete-stemcell
+delete-stemcell-gce: set-gce delete-stemcell
+delete-stemcell:
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) \
+			'bosh stemcells | grep -v -e + | grep -v -e Name -e "Stemcells total" -e "Currently in-use" | cut -d "|" -f 2,4 | tr "|" " " | grep -v ^$$ | while read -r stemcell; do bosh -n delete stemcell $$stemcell --force; done'
+
 delete-route-gce:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash ./delete-route.sh'
 

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,6 @@ provision-gce: set-gce prepare-provision provision
 provision: check-env-vars
 	@ssh -t -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash provision.sh $(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bosh_ip)'
 
-bosh-delete-aws: set-aws bosh-delete
-bosh-delete-gce: set-gce bosh-delete delete-route-gce
-bosh-delete:
-	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) './bosh-init delete manifest_${dir}.yml'
 delete-deployment-aws: set-aws delete-deployment
 delete-deployment-gce: set-gce delete-deployment
 delete-deployment:
@@ -55,6 +51,11 @@ delete-stemcell:
 
 delete-route-gce:
 	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) '/bin/bash ./delete-route.sh'
+
+bosh-delete-aws: set-aws delete-deployment delete-release delete-stemcell bosh-delete
+bosh-delete-gce: set-gce delete-deployment delete-release delete-stemcell bosh-delete delete-route-gce
+bosh-delete:
+	@ssh -oStrictHostKeyChecking=no ubuntu@$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip) 'yes | ./bosh-init delete manifest_${dir}.yml'
 
 destroy-aws: set-aws destroy
 destroy-gce: set-gce destroy

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -34,6 +34,8 @@ ssh-add ~/.ssh/id_rsa
 tr -d '\n' < account.json > account_tmp.json
 python -c 'print open("manifest_gce.yml").read().replace("ACCOUNT_JSON", open("account_tmp.json").read()).rstrip().rstrip("EOF")' > microbosh-manifest.yml 2>&1
 rm account_tmp.json manifest_gce.yml
+ln -sf microbosh-manifest.yml manifest_gce.yml
+ln -sf microbosh-manifest-state.json manifest_gce-state.json
 
 # Login to GCE
 export CLOUDSDK_PYTHON_SITEPACKAGES=1


### PR DESCRIPTION
**What**

[Automatically destroy CF environments](https://www.pivotaltracker.com/story/show/102832380)

**Acceptance Criteria**

**Given** that I have a CF environment on AWS
**And** a script to destroy the environment
**When** I run the destroy script
**Then** all the infrastructure that was created in order to deploy CF is destroyed including BOSH.

**Given** that I have a CF environment on GCE
**And** a script to destroy the environment
**When** I run the destroy script
**Then** all the infrastructure that was created in order to deploy CF is destroyed including BOSH.

**How this PR should be reviewed**

This PR should be reviewed in the following context:
- I want to make the Makefile operate in the same way for `GCE` as `AWS`, AWS uses `manifest_aws.yml` as it's manifest file while GCE uses `microbosh-manifest.yml`. 
  As a ["temporary fix"](https://www.pivotaltracker.com/story/show/102890622), I am going to link the following files:
  -  `microbosh-manifest.yml` -> `manifest_gce.yml` and;
  -  `microbosh-manifest-state.json` -> `manifest_gce-state.json`
- I want to delete all deployments that bosh has created
- I want to delete all releases that bosh has uploaded
- I want to remove all stemcells that have been uploaded
- I want to remove bosh entirely without having to be asked
- I want to destroy the environment and warn you that this is a destructive operation
- I have been told that ubuntu uses /bin/sh as the default shell to run Makefile commands so I want to change this to be /bin/bash so the `bash read function` works properly.

**How to test this PR**

This PR can be tested by starting up a new environment in AWS and GCE and then destroying it, followed by checking the relevant IaaS console to ensure all resources have been clean up correctly e.g.

For AWS:

```
make aws DEPLOY_ENV=$MY_ENVIRONMENT
make destroy-aws DEPLOY_ENV=$MY_ENVIRONMENT
```

For FCE

```
make gce DEPLOY_ENV=$MY_ENVIRONMENT
make destroy-gce DEPLOY_ENV=$MY_ENVIRONMENT
```

**Who should review this PR**
- A Warbling Wallaby, if a tuneful macropod is unavailable then a suitably toned member of the core team can serve as a substitute reviewer
- Any member of the core team can merge this PR with the exception of @jonty who I paired with :p
