### PR TITLE
[#102890622] Normalise the name of the GCE CF manifest file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ gce: set-gce apply prepare-provision provision
 apply-aws: set-aws apply
 apply-gce: set-gce apply
 apply: check-env-vars
-	@cd ${dir} && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV}
+	@cd ${dir} && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} -var gce_account_json="`tr -d '\n' < account.json`"
 
 confirm-execution:
 	@read -sn 1 -p "This is a destructive operation, are you sure you want to do this [Y/N]? "; [[ $${REPLY:0:1} = [Yy] ]];

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ set-aws:
 	$(eval dir=aws)
 set-gce:
 	$(eval dir=gce)
+	$(eval apply_suffix=-var gce_account_json="`tr -d '\n' < account.json`")
 bastion:
 	$(eval bastion=$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip))
 
@@ -22,7 +23,7 @@ gce: set-gce apply prepare-provision provision
 apply-aws: set-aws apply
 apply-gce: set-gce apply
 apply: check-env-vars
-	@cd ${dir} && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} -var gce_account_json="`tr -d '\n' < account.json`"
+	@cd ${dir} && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} ${apply_suffix}
 
 confirm-execution:
 	@read -sn 1 -p "This is a destructive operation, are you sure you want to do this [Y/N]? "; [[ $${REPLY:0:1} = [Yy] ]];

--- a/gce/manifest.tf
+++ b/gce/manifest.tf
@@ -7,7 +7,8 @@ resource "template_file" "manifest" {
         gce_default_zone  =  "${var.gce_region_zone}"
         gce_ssh_user      =  "${var.ssh_user}"
         gce_ssh_key_path  =  ".ssh/id_rsa"
-        gce_microbosh_net = "${google_compute_network.bastion.name}"
+        gce_microbosh_net =  "${google_compute_network.bastion.name}"
+        gce_account_json  =  "${var.gce_account_json}"
     }
 
     provisioner "local-exec" {

--- a/gce/manifest.tf
+++ b/gce/manifest.tf
@@ -12,7 +12,7 @@ resource "template_file" "manifest" {
     }
 
     provisioner "local-exec" {
-        command = "echo '${template_file.manifest.rendered}' > manifest.yml"
+        command = "/bin/echo '${template_file.manifest.rendered}' > manifest.yml"
     }
 }
 

--- a/gce/manifest.yml.tpl
+++ b/gce/manifest.yml.tpl
@@ -105,7 +105,7 @@ jobs:
       google: &google_properties
         project: ${gce_project_id}
         json_key: |
-                    ACCOUNT_JSON
+          ${gce_account_json}
         default_zone: ${gce_default_zone}
 
       dns:

--- a/gce/provider.tf
+++ b/gce/provider.tf
@@ -1,5 +1,5 @@
 provider "google" {
-  account_file = "${var.gce_account_file}"
+  account_file = "${file("account.json")}"
   project = "${var.gce_project}"
   region = "${var.gce_region}"
 }

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -30,13 +30,6 @@ chmod 400 ~/.ssh/id_rsa ~/.ssh/id_rsa.pub ~/account.json
 eval `ssh-agent`
 ssh-add ~/.ssh/id_rsa
 
-# Populate microbosh manifest with GCE credentials
-tr -d '\n' < account.json > account_tmp.json
-python -c 'print open("manifest_gce.yml").read().replace("ACCOUNT_JSON", open("account_tmp.json").read()).rstrip().rstrip("EOF")' > microbosh-manifest.yml 2>&1
-rm account_tmp.json manifest_gce.yml
-ln -sf microbosh-manifest.yml manifest_gce.yml
-ln -sf microbosh-manifest-state.json manifest_gce-state.json
-
 # Login to GCE
 export CLOUDSDK_PYTHON_SITEPACKAGES=1
 ACCOUNT=`json_get account.json client_email`
@@ -54,11 +47,11 @@ if [ ! -x bosh-init ]; then
 fi
 export BOSH_INIT_LOG_LEVEL=debug
 export BOSH_INIT_LOG_PATH=bosh-init.log
-time ./bosh-init deploy microbosh-manifest.yml
+time ./bosh-init deploy manifest_gce.yml
 
 # Configure internal routing for microbosh
 # 1. Get microbosh IP
-BOSH_VM=`json_get microbosh-manifest-state.json current_vm_cid`
+BOSH_VM=`json_get manifest_gce-state.json current_vm_cid`
 gcloud compute instances describe --zone $MICROBOSH_ZONE --format json $BOSH_VM > microbosh-info.json
 BOSH_INTERNAL_IP=`json_get microbosh-info.json networkInterfaces '[0]["networkIP"]'`
 

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -1,8 +1,3 @@
-variable "gce_account_file" {
-  description = "JSON Account Credentials file for GCE"
-  default = "account.json"
-}
-
 variable "gce_project" {
   description = "GCE Project Name to create machines inside of"
   default = "root-unison-859"

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -43,3 +43,7 @@ variable "bastion_cidr" {
   default = "10.0.0.0/24"
 }
 
+variable "gce_account_json" {
+  describe    = "To be replaced with actual contents of account.json at runtime."
+  default     = "changeme"
+}

--- a/globals.tf
+++ b/globals.tf
@@ -16,3 +16,8 @@ variable "microbosh_IP" {
   description = "microbosh internal IP. Do not change. This is more of a constant than variable."
   default     = "10.0.0.6"
 }
+
+variable "gce_account_json" {
+  describe    = "To be replaced with actual contents of account.json at runtime. Ignored in AWS."
+  default     = "changeme"
+}

--- a/globals.tf
+++ b/globals.tf
@@ -16,8 +16,3 @@ variable "microbosh_IP" {
   description = "microbosh internal IP. Do not change. This is more of a constant than variable."
   default     = "10.0.0.6"
 }
-
-variable "gce_account_json" {
-  describe    = "To be replaced with actual contents of account.json at runtime. Ignored in AWS."
-  default     = "changeme"
-}


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/102890622

Instead of rendering/replacing account json into microbosh manifest on bastion host, do that already when rendering mBosh template on localhost. To do that, we need to put contents of account.json into TF variable, which can then be used inside the manifest. This is done in Makefile. Implementation is such that we don't have to have 2 different logical branches for gce and aws in makefile because of this. The variable gets defined to empty in AWS, which doesn't matter, as it's not being used there.

_testing_

Deploy GCE environment using make. All should work. It's enough to wait till bosh-init creates mBosh server, confirming that it has read the account json credentials and was able to create new server.

_who_

not @mtekel
