### PR TITLE
[#103088676] Cloud foundry smoke test on GCE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ gce/cf-manifest.yml
 gce/account.json
 *.tfstate
 *.tfstate.backup
+gce/.terraform
+aws/.terraform
+*smoke_test*.json

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ gce: set-gce apply prepare-provision provision
 apply-aws: set-aws apply
 apply-gce: set-gce apply
 apply: check-env-vars
-	@cd ${dir} && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} ${apply_suffix}
+	@cd ${dir} && terraform get && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} ${apply_suffix}
 
 confirm-execution:
 	@read -sn 1 -p "This is a destructive operation, are you sure you want to do this [Y/N]? "; [[ $${REPLY:0:1} = [Yy] ]];
@@ -32,6 +32,12 @@ prepare-provision: bastion
 	@cd ${dir} && scp -oStrictHostKeyChecking=no provision.sh ubuntu@${bastion}:provision.sh
 	@cd ${dir} && scp -oStrictHostKeyChecking=no cf-manifest.yml ubuntu@${bastion}:cf-manifest.yml
 	@cd ${dir} && scp -oStrictHostKeyChecking=no manifest.yml ubuntu@${bastion}:manifest_${dir}.yml
+
+test-aws: set-aws test
+test-gce: set-gce test
+test: bastion
+	@cd ${dir} && scp -oStrictHostKeyChecking=no smoke_test_${DEPLOY_ENV}.json ubuntu@${bastion}:smoke_test.json
+	@ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash smoke_test.sh'
 
 provision-aws: set-aws prepare-provision provision
 provision-gce: set-gce prepare-provision provision

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -41,4 +41,17 @@ resource "google_compute_instance" "bastion" {
           destination = "/home/ubuntu/delete-route.sh"
   }
 
+  provisioner "file" {
+        source = "${module.smoke_test.script_path}"
+        destination = "/home/ubuntu/smoke_test.sh"
+  }
+
+}
+
+module "smoke_test" {
+  source = "../smoke_test"
+
+  haproxy_ip = "${google_compute_address.haproxy.address}"
+  env = "${var.env}"
+
 }

--- a/smoke_test/smoke_test.json.erb
+++ b/smoke_test/smoke_test.json.erb
@@ -1,0 +1,15 @@
+{
+  "suite_name"         : "CF_SMOKE_TESTS",
+  "api"                : "api.<%= haproxy_ip %>.xip.io",
+  "apps_domain"        : "<%= haproxy_ip %>.xip.io",
+  "user"               : "admin",
+  "password"           : "c1oudc0w",
+  "org"                : "CF-SMOKE-ORG",
+  "space"              : "CF-SMOKE-SPACE",
+  "cleanup"            : true,
+  "use_existing_org"   : false,
+  "use_existing_space" : false,
+  "logging_app"        : "",
+  "runtime_app"        : "",
+  "skip_ssl_validation": true
+}

--- a/smoke_test/smoke_test.sh
+++ b/smoke_test/smoke_test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+go_version=1.5.1
+cf_version=6.12.3
+smoke_test_version=4ea03845eeb5237bc5630926356ea223436a28dd
+
+
+echo Check go version ${go_version}
+if [[ ! -d /usr/local/go ]] || [[ "`/usr/local/go/bin/go version`" != *"${go_version}"* ]] ; then
+	sudo rm -rf /usr/local/go
+	wget https://storage.googleapis.com/golang/go${go_version}.linux-amd64.tar.gz
+	sudo tar -C /usr/local -xzf go${go_version}.linux-amd64.tar.gz
+	rm go${go_version}.linux-amd64.tar.gz
+fi
+export PATH=$PATH:/usr/local/go/bin
+
+echo Check cloud foundry cli version ${cf_version}
+if ! cf_version_orig=`dpkg-query -W cf-cli` || [[ "${cf_version_orig}" != *"${cf_version}"* ]]; then
+	sudo dpkg -r cf-cli
+	wget -O cf-cli_${cf_version}_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=${cf_version}&source=github-rel"
+	sudo dpkg -i cf-cli_${cf_version}_amd64.deb
+fi
+
+echo Retrieving smoke test version ${smoke_test_version}...
+[[ ! -d cf-smoke-tests ]] && git clone https://github.com/cloudfoundry/cf-smoke-tests.git
+cd cf-smoke-tests
+git checkout ${smoke_test_version}
+export GOPATH=${HOME}/cf-smoke-tests
+
+echo Run smoke test
+CONFIG=$HOME/smoke_test.json bin/test -v 

--- a/smoke_test/smoke_test.tf
+++ b/smoke_test/smoke_test.tf
@@ -1,0 +1,18 @@
+variable "haproxy_ip" {}
+variable "env" {}
+
+resource "template_file" "smoke_test_json" {
+    filename = "${path.module}/smoke_test.json.erb"
+
+    vars {
+        noop = "do nothing, we render with erb in local provisioner"
+    }
+
+    provisioner "local-exec" {
+        command = "(echo '<% haproxy_ip=\"${var.haproxy_ip}\" %>' && cat ${path.module}/smoke_test.json.erb) | erb > smoke_test_${var.env}.json"
+    }
+}
+
+output "script_path" {
+    value = "${path.module}/smoke_test.sh"
+}


### PR DESCRIPTION
We would like to be able to run a smoke test against a cloud foundry environment.
# What
-  Use the basic suite of tests that is [already available](https://github.com/cloudfoundry/cf-smoke-tests) from the community. It runs 2 suites: `CF-Logging-Smoke-Tests` and `CF-Runtime-Smoke-Tests`.
-  The smoke test configuration file is generated locally by `terraform`, and uploaded via `make`.
-  Add a new `make` action. It can be integrated to a pipeline later.
-  The version of each dependency (`go`, `cf`, `smoke_test`) has been pinned and can be changed in the script `smoke_test.sh`
-  The same smoke test should run on AWS and GCE. To avoid duplication, the code is in a separate module that can be included in each one. If necessary the module can easily be relocated in its own repository later.
-  The `terraform apply` now requires running `terraform get` to fetch the module. This has been added to the `Makefile`.
-  This was only tested on GCE as AWS cloud foundry is not ready yet.
# How to review
- **Prerequisite:** Use terraform client version 0.6.2 or above
-  Build a new GCE environment:

```
make gce DEPLOY_ENV=smoke_test_123
```
-  Run the smoke test:

```
make test-gce DEPLOY_ENV=smoke_test_123
```

The output should be:

```
Ginkgo ran 2 suites in 1m38.405146534s
Test Suite Passed
```
# Who can review

Anyone but @saliceti
