### PR TITLE
[#103313294] Add postgreSQL service

### DIFF
--- a/deploy_psql_broker.sh
+++ b/deploy_psql_broker.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+echo "*** Deploying and registering PostgreSQL broker..."
+
+ADMIN_PASS="administrator"
+ADMIN_USER="admin"
+PSQL_SERVER=`bosh vms | grep postgres/0 | grep -o '10\.[0-9]\+\.[0-9]\+\.[0-9]\+'`
+DOMAIN=`python -c 'import yaml; print yaml.load(file("cf-manifest.yml"))["properties"]["domain"]'`
+CF_PASS="c1oudc0w"
+
+cf_version=6.12.3
+if ! cf_version_orig=`dpkg-query -W cf-cli` || [[ "${cf_version_orig}" != *"${cf_version}"* ]]; then
+	sudo dpkg -r cf-cli
+	wget -O cf-cli_${cf_version}_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=${cf_version}&source=github-rel"
+	sudo dpkg -i cf-cli_${cf_version}_amd64.deb
+fi
+
+PACKAGES="maven openjdk-7-jdk"
+if ! dpkg -l $PACKAGES > /dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y $PACKAGES
+fi
+# The two above should be part of provision sh
+
+echo "*** Logging in to CF and creating admin space..."
+cf api --skip-ssl-validation https://api.${DOMAIN}
+cf login -u ${ADMIN_USER} -p ${CF_PASS}
+cf create-space admin
+cf target -o admin -s admin
+
+if [ ! -d postgresql-cf-service-broker ]; then
+  git clone https://github.com/cloudfoundry-community/postgresql-cf-service-broker.git
+fi
+
+cd postgresql-cf-service-broker
+git checkout 5eb470f027f803d7de3117add71630aac08ba33c
+
+mvn package -DskipTests
+
+cf push postgresql-cf-service-broker -p target/postgresql-cf-service-broker-2.3.0-SNAPSHOT.jar --no-start
+cd ..
+
+cf set-env postgresql-cf-service-broker JAVA_OPTS "-Dsecurity.user.password=${ADMIN_PASS}"
+cf set-env postgresql-cf-service-broker MASTER_JDBC_URL "jdbc:postgresql://${PSQL_SERVER}:5432/psqlbroker?user=${ADMIN_USER}&password=${ADMIN_PASS}"
+cf start postgresql-cf-service-broker
+URL=`cf app postgresql-cf-service-broker | grep urls: | awk '{print $2}'`
+
+# Only register if not done already
+cf service-brokers | grep -q ${URL}
+if [[ ! $? == 0 ]] ; then
+  cf create-service-broker postgresql-cf-service-broker user ${ADMIN_PASS} http://${URL}
+  cf enable-service-access PostgreSQL -p "Basic PostgreSQL Plan"
+fi

--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -41,6 +41,11 @@ resource "google_compute_instance" "bastion" {
           destination = "/home/ubuntu/delete-route.sh"
   }
 
+   provisioner "file" {
+          source = "${path.module}/../deploy_psql_broker.sh"
+          destination = "/home/ubuntu/deploy_psql_broker.sh"
+  }
+
   provisioner "file" {
         source = "${module.smoke_test.script_path}"
         destination = "/home/ubuntu/smoke_test.sh"

--- a/gce/cf210-manifest.yml.erb
+++ b/gce/cf210-manifest.yml.erb
@@ -86,6 +86,11 @@ disk_pools:
     cloud_properties:
       type: pd-ssd
 
+  - name: postgres
+    disk_size: 40_000
+    cloud_properties:
+      type: pd-standard
+
 jobs:
   - name: haproxy
     templates:
@@ -161,6 +166,37 @@ jobs:
         default: [dns, gateway]
     update:
       max_in_flight: 1
+
+  - name: postgres
+    templates:
+      - name: postgres
+      - name: metron_agent
+    instances: 1
+    resource_pool: common
+    persistent_disk_pool: postgres
+    networks:
+      - name: default
+        default: [dns, gateway]
+    properties:
+      databases:
+        db_scheme: postgres
+        port: 5432
+        address: 0.postgres.default.<%= deployment_name %>.microbosh
+        max_connections: 500
+        log_line_prefix: "psql %m:"
+        roles:
+          - tag: admin
+            name: admin
+            password: administrator
+            permissions:
+              - SUPERUSER
+              - INHERIT
+              - CREATEROLE
+              - CREATEDB
+              - LOGIN
+        databases:
+          - tag: psqlbroker
+            name: psqlbroker
 
 properties:
   networks:

--- a/gce/cf211-manifest.yml.erb
+++ b/gce/cf211-manifest.yml.erb
@@ -499,10 +499,10 @@ properties:
     external_protocol: <%= protocol %>
 
   dea: &dea
-    disk_mb: 102400
+    disk_mb: 40000
     disk_overcommit_factor: 2
-    memory_mb: 51200
-    memory_overcommit_factor: 3
+    memory_mb: 10000
+    memory_overcommit_factor: 2
     staging_disk_inode_limit: 200000
     instance_disk_inode_limit: 200000
     kernel_network_tuning_enabled: true

--- a/gce/cf211-manifest.yml.erb
+++ b/gce/cf211-manifest.yml.erb
@@ -4,7 +4,7 @@ static_ip = "#{tf_static_ip}"
 deployment_name = "#{tf_deployment_name}"
 network_name = "#{tf_network_name}"
 root_domain = "#{static_ip}.xip.io"
-cf_release = "210"
+cf_release = "211"
 protocol = "http"
 common_password = "c1oudc0w"
 %>

--- a/gce/manifest.tf
+++ b/gce/manifest.tf
@@ -17,13 +17,13 @@ resource "template_file" "manifest" {
 }
 
 resource "template_file" "cf-manifest" {
-    filename = "${path.module}/cf210-manifest.yml.erb"
+    filename = "${path.module}/cf211-manifest.yml.erb"
 
     vars {
         noop = "do nothing, we render with erb in local provisioner"
     }
 
     provisioner "local-exec" {
-        command = "(echo '<% tf_static_ip=\"${google_compute_address.haproxy.address}\" ; tf_deployment_name=\"${var.env}\" ; tf_network_name=\"${google_compute_network.bastion.name}\" %>' && cat ${path.module}/cf210-manifest.yml.erb) | erb > cf-manifest.yml"
+        command = "(echo '<% tf_static_ip=\"${google_compute_address.haproxy.address}\" ; tf_deployment_name=\"${var.env}\" ; tf_network_name=\"${google_compute_network.bastion.name}\" %>' && cat ${path.module}/cf211-manifest.yml.erb) | erb > cf-manifest.yml"
     }
 }

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -141,4 +141,7 @@ sed -i "s/BOSH_UUID/$(bosh status --uuid)/" cf-manifest.yml
 bosh deployment cf-manifest.yml
 time bosh -n deploy
 
+# Deploy and register PSQL broker
+time bash deploy_psql_broker.sh
+
 #TODO: run CATS (CF acceptance tests) to verify deployment health

--- a/gce/provision.sh
+++ b/gce/provision.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 STEMCELL=light-bosh-stemcell-2968-google-kvm-ubuntu-trusty-go_agent.tgz
-RELEASE=210
+RELEASE=211
 BOSH_EXTERNAL_IP=$1
 MICROBOSH_ZONE=europe-west1-b
 DEPLOYMENT_NAME=`python -c 'import yaml; print yaml.load(file("cf-manifest.yml"))["name"]'`


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/103313294

Add postgreSQL shared VM service into CF:
- add a postgreSQL server: we use postgres job from CF release, we had to bump version to 211, because we need PSQL 9.1 at least and CF210 only had 9.0. 211 has 9.4.
- build the broker: we build on the bastion host, it requires maven. CF java buildpack only supports deploying binaries...
- deploy and register PSQL broker: use cf cli to push the app and register the broker and service
# Testing

`make gce DEPLOY_ENV=<your environment>`

At the end of deploy you should be able to list PSQL service in marketplace: `cf m`:

```
cf m
Getting services from marketplace in org admin / space admin as admin...
OK

service      plans                    description   
PostgreSQL   Basic PostgreSQL Plan*   PostgreSQL on shared instance.   

* These service plans have an associated cost. Creating a service instance will incur this cost.
```

You can also check service information with `cf m -s PostgreSQL`:

```
ubuntu@michael-cf-bastion:~$ cf m -s PostgreSQL
Getting service plan information for service PostgreSQL as admin...
OK

service plan            description                                                                        free or paid   
Basic PostgreSQL Plan   A PG plan providing a single database on a shared instance with limited storage.   paid   
```

You can create service instance and bind it to some app and then check environment variables, you should get st. like

```
cf env flaskapp
Getting env variables for app flaskapp in org admin / space admin as admin...
OK

System-Provided:
{
 "VCAP_SERVICES": {
  "PostgreSQL": [
   {
    "credentials": {
     "uri": "postgres://cff7468f-9156-4044-8acc-6a7e9f777108:2gjb02o6katmfrdl0p3lmvc7a1@10.0.0.253:5432/cff7468f-9156-4044-8acc-6a7e9f777108"
    },
    "label": "PostgreSQL",
    "name": "mypostgres",
    "plan": "Basic PostgreSQL Plan",
    "tags": [
     "PostgreSQL",
     "Database storage"
    ]
   }
  ]
 }
}
```

The flask app has been [patched](https://github.com/alphagov/flask-sqlalchemy-postgres-heroku-example/commit/716513f7ecc765337685a1529685a93bba97b4d9) to support the CF VCAP services natively rather than requiring them to be manually specified as in https://www.pivotaltracker.com/n/projects/1275640/stories/102980618

You can also check service instance information by `cf service <servicename>`:

```
ubuntu@michael-cf-bastion:~$ cf service mypostgres

Service instance: mypostgres
Service: PostgreSQL
Plan: Basic PostgreSQL Plan
Description: PostgreSQL on shared instance.
Documentation url: http://mendix.com/postgresql
Dashboard: 

Last Operation
Status: create succeeded
Message: 
Started: 2015-09-16T10:14:41Z
Updated: 2015-09-16T10:14:41Z
```
# Testing

Not @mtekel or @Jonty 
