### PR TITLE
Uncomment the ./update.sh line

### DIFF
--- a/aws/provision.sh
+++ b/aws/provision.sh
@@ -55,7 +55,7 @@ fi
 echo "Uploading v215 release to bosh..."
 cd cf-release
 git checkout v215
-#./update
+./update
 time bosh upload release releases/cf-215.yml
 
 # Upload elasticsearch release


### PR DESCRIPTION
**What**

The ./update.sh step in the provision.sh script was commented out by mistake in a previous PR. It was not required when deploying to GCE, but is required for AWS where we're using spiff to generate the templates. The template for cf-lamb.yml is a symlink into the loggregator directory which is not populated until after ./update.sh is run. 

This PR restores the update.sh step by removing the # symbol at the start of the line.

*\* Testing **
make aws DEPLOY_ENV=<env>
Deployment should succeed.

**Who**

Anyone except for @jimconner can merge this PR.
