### PR TITLE
[#104310224] Pin the dependencies used in the build: bosh_cli

### DIFF
--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem 'bosh_cli', '~> 1.3056.0'
+gem 'net-ssh', '~> 2.9.2'
+

--- a/scripts/Gemfile.lock
+++ b/scripts/Gemfile.lock
@@ -1,0 +1,172 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.1)
+    aws-sdk (1.60.2)
+      aws-sdk-v1 (= 1.60.2)
+    aws-sdk-v1 (1.60.2)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+    blobstore_client (1.3056.0)
+      aws-sdk (= 1.60.2)
+      bosh_common (~> 1.3056.0)
+      fog (~> 1.31.0)
+      fog-aws (<= 0.1.1)
+      httpclient (= 2.4.0)
+      multi_json (~> 1.1)
+    bosh-template (1.3056.0)
+      semi_semantic (~> 1.1.0)
+    bosh_cli (1.3056.0)
+      blobstore_client (~> 1.3056.0)
+      bosh-template (~> 1.3056.0)
+      bosh_common (~> 1.3056.0)
+      cf-uaa-lib (~> 3.2.1)
+      highline (~> 1.6.2)
+      httpclient (= 2.4.0)
+      json_pure (~> 1.7)
+      minitar (~> 0.5.4)
+      net-scp (~> 1.1.0)
+      net-ssh (>= 2.2.1)
+      net-ssh-gateway (~> 1.2.0)
+      netaddr (~> 1.5.0)
+      progressbar (~> 0.9.0)
+      terminal-table (~> 1.4.3)
+    bosh_common (1.3056.0)
+      logging (~> 1.8.2)
+      semi_semantic (~> 1.1.0)
+    builder (3.2.2)
+    cf-uaa-lib (3.2.4)
+      multi_json
+    excon (0.45.4)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.31.0)
+      fog-atmos
+      fog-aws (~> 0.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.30)
+      fog-ecloud
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.9.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.32.1)
+      builder
+      excon (~> 0.45)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.0.9)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.5)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.3.2)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.7)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    highline (1.6.21)
+    httpclient (2.4.0)
+    inflecto (0.0.2)
+    ipaddress (0.8.0)
+    json (1.8.3)
+    json_pure (1.8.2)
+    little-plugger (1.1.4)
+    logging (1.8.2)
+      little-plugger (>= 1.1.3)
+      multi_json (>= 1.8.4)
+    mime-types (2.6.2)
+    mini_portile (0.6.2)
+    minitar (0.5.4)
+    multi_json (1.11.2)
+    net-scp (1.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
+    netaddr (1.5.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    progressbar (0.9.2)
+    semi_semantic (1.1.0)
+    terminal-table (1.4.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bosh_cli (~> 1.3056.0)
+  net-ssh (~> 2.9.2)
+
+BUNDLED WITH
+   1.10.6

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -75,10 +75,7 @@ function install_dependencies {
     sqlite3
     dstat
     unzip
-  "
-
-  GEMS="
-    bosh_cli:${BOSH_CLI_VERSION}
+    bundler
   "
 
   echo "Installing system packages..."
@@ -88,13 +85,7 @@ function install_dependencies {
   fi
 
   echo "Installing gem packages..."
-  for gem in $GEMS; do
-    local gem_name=$(echo $gem | cut -f 1 -d : )
-    local gem_version=$(echo $gem | cut -f 2 -d : )
-    if ! gem list | grep -q "$gem_name ($gem_version)"; then
-      sudo gem install $gem_name ${gem_version:+--version $gem_version} --no-ri --no-rdoc
-    fi
-  done
+  bundle install --gemfile=$SCRIPT_DIR/Gemfile --quiet
 
   echo "Installing binaries: bosh-init, spiff, cf..."
   if [ ! -x /usr/local/bin/bosh-init ]; then

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -65,7 +65,7 @@ function install_dependencies {
     zlib1g-dev
     ruby
     ruby-dev openssl
-    libxslt-dev
+    libxslt1-dev
     libxml2-dev
     libssl-dev
     libreadline6
@@ -82,7 +82,7 @@ function install_dependencies {
   "
 
   echo "Installing system packages..."
-  if ! dpkg -l $PACKAGES > /dev/null 2>&1; then
+  if dpkg-query -W -f='${Status}\n' $PACKAGES | grep -q not-installed -q; then
     sudo apt-get -y update
     sudo apt-get install -y $PACKAGES
   fi

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -82,7 +82,7 @@ function install_dependencies {
   "
 
   echo "Installing system packages..."
-  if dpkg-query -W -f='${Status}\n' $PACKAGES | grep -q not-installed -q; then
+  if dpkg-query -W -f='${Package} ${Status}\n' $PACKAGES 2>&1 | grep -v 'ok installed' | grep  '^..*$'; then
     sudo apt-get -y update
     sudo apt-get install -y $PACKAGES
   fi


### PR DESCRIPTION
[#104310224 Pin the dependencies used in the build: bosh_cli](https://www.pivotaltracker.com/story/show/104310224)
# What

The latest publish version of `net-ssh`, which `bosh_cli` depends on, requires ruby 2.0. But Ruby 2.0 is not installed by default in the bastion host and it fails. To workaround this issue and any future one, we want to pin all the `bosh_cli` and its dependencies.
# Context

In order to pin `bosh_cli` and its dependencies, we will use a `Gemfile` and `Gemfile.lock` with bundler. This PR does:
- Install bundler from apt repository
- Defines a Gemfile pinning `bosh_cli` and `net-ssh` to the right version (latest version of `net-ssh` that works on ruby 1.9 is 2.9.1)
# How to test this.

You only need to run the install dependencies of provision.sh. For that:
1. Optional: Add a `exit 0` after `install_dependencies` in `scripts/provision.sh` to stop after install dependencies.
2. Run `make aws DEPLOY_ENV=<env>` or `make gce DEPLOY_ENV=<env>`
3. Once it is finish, check that `bosh` command line is installed in the bastion.
# Who can review this

Anyone buy @keymon
