### PR TITLE
[#103419194] Setup NAT masquerading on AWS

### DIFF
--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -37,4 +37,9 @@ resource "aws_instance" "bastion" {
       "chmod 400 /home/ubuntu/.ssh/id_rsa"
     ]
   }
+
+  provisioner "remote-exec" {
+    script = "../scripts/setup-nat-routing.sh"
+  }
+
 }

--- a/aws/cf-subnet.tf
+++ b/aws/cf-subnet.tf
@@ -3,16 +3,23 @@ resource "aws_subnet" "cf" {
   vpc_id            = "${aws_vpc.default.id}"
   cidr_block        = "${lookup(var.cf_cidrs, concat("zone", count.index))}"
   availability_zone = "${lookup(var.zones, concat("zone", count.index))}"
-  map_public_ip_on_launch = true
-  depends_on = ["aws_internet_gateway.default"]
+  map_public_ip_on_launch = false
+  depends_on = ["aws_instance.bastion"]
   tags {
     Name = "${var.env}-cf-subnet-${count.index}"
+  }
+}
+
+resource "aws_route_table" "cf" {
+  vpc_id = "${aws_vpc.default.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    instance_id = "${aws_instance.bastion.id}"
   }
 }
 
 resource "aws_route_table_association" "cf" {
   count = 2
   subnet_id = "${element(aws_subnet.cf.*.id, count.index)}"
-  route_table_id = "${aws_route_table.internet.id}"
+  route_table_id = "${aws_route_table.cf.id}"
 }
-

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -17,6 +17,15 @@ resource "aws_security_group" "bastion" {
     cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
 
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    security_groups = [
+      "${aws_security_group.bosh_vm.id}"
+    ]
+  }
+
   tags {
     Name = "${var.env}-bastion"
   }

--- a/scripts/setup-nat-routing.sh
+++ b/scripts/setup-nat-routing.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Redirect stdout ( > ) into a log file.
+exec > /tmp/setup-nat-routing.log
+exec 2>&1
+
+set -e
+
+echo "NAT: Enabling routing features in the kernel"
+echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward
+echo 0 | sudo tee /proc/sys/net/ipv4/conf/eth0/send_redirects
+sudo mkdir -p /etc/sysctl.d/
+echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/nat.conf
+echo 'net.ipv4.conf.eth0.send_redirects = 0' | sudo tee -a /etc/sysctl.d/nat.conf
+
+echo "NAT: Setting up NAT-MASQUERADE"
+sudo iptables -t nat -A POSTROUTING -o eth0 -s 0.0.0.0/0 -j MASQUERADE
+
+# Cloudinit changes the package repositories, which can make fail next steps.
+# Let's wait for it to finish.
+while pgrep cloud-init > /dev/null; do echo "Waiting for cloudinit to finish..."; sleep 1; done
+
+echo "Save iptables state"
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
+sudo service iptables-persistent save
+


### PR DESCRIPTION
**What**
- I do not want my private Cloud Foundry VMs to have public ip addresses
- I also do not want green eggs and ham.

**How to review this PR**

This PR has been written with the following narrative:
- I want set up IP masquerading on the bastion so I can route internet traffic through it
- I want to turn off public mapping of IP address and set the default route to be via the bastion box
- I want to allow all traffic from the bosh VMs to the bastion

**How to test this PR**

To test this PR launch an AWS environment and confirm in the `AWS console` that only bosh and bastion have public IP addresses.

```
make aws DEPLOY_ENV=$SAM_I_AM
```

Test deploying an application (spring music for example) and confirm that everything works as expected.

**Who should review and merge this PR**
- Anyone on the on the main team except @jimconner or I since...
  - I would not merge it in a house
  - I would not merge it with a mouse
  - I would not merge it here or there
  - I would not merge it anywhere
