### PR TITLE
Add missing bosh_subnet_id in the terraform output

### DIFF
--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -22,6 +22,10 @@ output "region" {
 	value = "${var.region}"
 }
 
+output "bosh_subnet_id" {
+	value = "${aws_subnet.infra.0.id}"
+}
+
 output "cf1_subnet_id" {
 	value = "${aws_subnet.cf.0.id}"
 }


### PR DESCRIPTION
# What

In PR #25 we accidentally miss one terraform output while rebasing commits. 

For the bosh manifest in AWS we need the bosh_subnet_id in the
terraform outputs. This variable was originally pass in the terraform
template.
# How to test this

Deploy a new environment with `make aws DEPLOY_ENV=...`
# who

anyone but me
