### PR TITLE
[#103073396] AWS: use default compilation VMs

### DIFF
--- a/manifests/templates/aws/cf-pool-instances.yml
+++ b/manifests/templates/aws/cf-pool-instances.yml
@@ -13,9 +13,6 @@ meta:
       cloud_properties:
           instance_type: c4.xlarge
 
-compilation:
-  cloud_properties: (( meta.resource_pools.large.cloud_properties ))
-
 resource_pools:
   - name: small_z1
     cloud_properties: (( meta.resource_pools.small.cloud_properties ))


### PR DESCRIPTION
As it turns out, you can't override a yaml property which doesn't exist in spiff. That is, in our merge chain, compination VMs only have zone and instance_type defined. Thus we can't define ephemeral disk. This means we can't currently use any AWS instances that are EBS only, which is all newer instance types. Revert compilation VMs back to default, which is c3.large, which has 2x 16GB SSD ephemeral storage.
# Testing

Build new environment. Verify compilation works.
# Reviewing

not @mtekel
