### PR TITLE
[#103926774] Could Foundry secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ prepare-provision: bastion
 	    manifests/generate_deployment_manifest.sh ubuntu@${bastion}:
 	@scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
 	@PASSWORD_STORE_DIR=~/.paas-pass pass cloudfoundry/cf-secrets.yml | ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-secrets.yml'
+	@PASSWORD_STORE_DIR=~/.paas-pass pass cloudfoundry/bosh-secrets.yml | ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/bosh-secrets.yml'
 
 test-aws: set-aws test
 test-gce: set-gce test

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ prepare-provision: bastion
 	    manifests/generate_bosh_manifest.sh \
 	    manifests/generate_deployment_manifest.sh ubuntu@${bastion}:
 	@scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
+	@PASSWORD_STORE_DIR=~/.paas-pass pass cloudfoundry/manifest_secrets.yml | ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/secrets.yml'
 
 test-aws: set-aws test
 test-gce: set-gce test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ endif
 
 set-aws:
 	$(eval dir=aws)
+	$(eval apply_suffix=-var uaadb_password=`PASSWORD_STORE_DIR=~/.paas-pass pass cloudfoundry/uaadb_password`\
+						-var ccdb_password=`PASSWORD_STORE_DIR=~/.paas-pass pass cloudfoundry/ccdb_password`)
 set-gce:
 	$(eval dir=gce)
 	$(eval apply_suffix=-var gce_account_json="`tr -d '\n' < account.json`")

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ prepare-provision: bastion
 	    manifests/generate_bosh_manifest.sh \
 	    manifests/generate_deployment_manifest.sh ubuntu@${bastion}:
 	@scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
-	@PASSWORD_STORE_DIR=~/.paas-pass pass cloudfoundry/manifest_secrets.yml | ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/secrets.yml'
+	@PASSWORD_STORE_DIR=~/.paas-pass pass cloudfoundry/cf-secrets.yml | ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-secrets.yml'
 
 test-aws: set-aws test
 test-gce: set-gce test

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ bosh-delete: bastion
 destroy-aws: confirm-execution set-aws bosh-delete-aws destroy
 destroy-gce: confirm-execution set-gce bosh-delete-gce destroy
 destroy:
-	@cd ${dir} && terraform destroy -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} -force
+	@cd ${dir} && terraform destroy -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} ${apply_suffix} -force
 
 show-aws: set-aws show
 show-gce: set-gce show

--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -13,8 +13,8 @@ resource "aws_db_instance" "uaadb" {
     engine_version = "5.6.23"
     instance_class = "db.t2.micro"
     name = "uaadb"
-    username = "uaadb"
-    password = "uaadbpassword"
+    username = "${var.uaadb_username}"
+    password = "${var.uaadb_password}"
     db_subnet_group_name = "${aws_db_subnet_group.cf_rds_subnet.name}"
     parameter_group_name = "default.mysql5.6"
     vpc_security_group_ids = ["${aws_security_group.rds.id}"]
@@ -27,8 +27,8 @@ resource "aws_db_instance" "ccdb" {
     engine_version = "5.6.23"
     instance_class = "db.t2.micro"
     name = "ccdb"
-    username = "ccdb"
-    password = "ccdbpassword"
+    username = "${var.ccdb_username}"
+    password = "${var.ccdb_password}"
     db_subnet_group_name = "${aws_db_subnet_group.cf_rds_subnet.name}"
     parameter_group_name = "default.mysql5.6"
     vpc_security_group_ids = ["${aws_security_group.rds.id}"]

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -78,6 +78,24 @@ variable "dns_zone_name" {
   default     = "cf.paas.alphagov.co.uk"
 }
 
+variable "uaadb_username" {
+  description = "UAA RDS DB username"
+  default     = "uaadb"
+}
+
+variable "uaadb_password" {
+  description = "UAA RDS DB password"
+}
+
+variable "ccdb_username" {
+  description = "Cloud Controller RDS DB username"
+  default     = "ccdb"
+}
+
+variable "ccdb_password" {
+  description = "Cloud Controller RDS DB password"
+}
+
 # Terraform currently only has limited support for reading environment variables
 # Variables for use with terraform must be prefexed with 'TF_VAR_'
 # These two variables are passed in as environment variables named:

--- a/manifests/generate_bosh_manifest.sh
+++ b/manifests/generate_bosh_manifest.sh
@@ -19,4 +19,5 @@ spiff merge \
   $templates/bosh/bosh-template.yml \
   $templates/${infrastructure}/bosh/*.yml \
   $templates/outputs/terraform-outputs-${infrastructure}.yml \
+  $templates/bosh-secrets.yml \
   "$@"

--- a/manifests/generate_deployment_manifest.sh
+++ b/manifests/generate_deployment_manifest.sh
@@ -35,5 +35,5 @@ spiff merge \
   $templates/${infrastructure}/stubs/*.yml \
   $templates/stubs/*.yml \
   $templates/outputs/terraform-outputs-${infrastructure}.yml \
-  $templates/secrets.yml \
+  $templates/cf-secrets.yml \
   "$@"

--- a/manifests/generate_deployment_manifest.sh
+++ b/manifests/generate_deployment_manifest.sh
@@ -21,7 +21,7 @@ case $infrastructure in
     exit 1
     ;;
 esac
-
+ 
 spiff merge \
   $CF_RELEASE_PATH/templates/cf-deployment.yml \
   $templates/deployments/*.yml \
@@ -35,4 +35,5 @@ spiff merge \
   $templates/${infrastructure}/stubs/*.yml \
   $templates/stubs/*.yml \
   $templates/outputs/terraform-outputs-${infrastructure}.yml \
+  $templates/secrets.yml \
   "$@"

--- a/manifests/templates/bosh/bosh-template.yml
+++ b/manifests/templates/bosh/bosh-template.yml
@@ -1,4 +1,6 @@
 ---
+secrets: (( merge ))
+
 meta:
   cpi-release: (( merge ))
 
@@ -28,7 +30,7 @@ meta:
   postgres:
     host: 127.0.0.1
     user: postgres
-    password: postgres-password
+    password: (( secrets.postgres_password ))
     database: bosh
     adapter: postgres
 
@@ -39,7 +41,7 @@ meta:
     recursor: 8.8.8.8
 
   default_agent:
-    mbus: (( "nats://nats:nats-password@" meta.bosh_service_ip ":4222" ))
+    mbus: (( "nats://nats:" secrets.nats_password "@" meta.bosh_service_ip ":4222" ))
 
 name: (( merge ))
 
@@ -78,12 +80,12 @@ jobs:
     nats:
       address: 127.0.0.1
       user: nats
-      password: nats-password
+      password: (( secrets.nats_password ))
 
     redis:
       listen_address: 127.0.0.1
       address: 127.0.0.1
-      password: redis-password
+      password: (( secrets.redis_password ))
 
     postgres: (( meta.postgres ))
 
@@ -92,14 +94,14 @@ jobs:
       provider: dav
       director:
         user: director
-        password: director-password
+        password: (( secrets.blobstore_director_password ))
       agent:
         user: agent
-        password: agent-password
+        password: (( secrets.agent_password ))
       options:
         endpoint: (( "http://" meta.bosh_public_ip ":25250" ))
         user: agent
-        password: agent-password
+        password: (( secrets.agent_password ))
 
     director:
       address: 127.0.0.1
@@ -110,7 +112,9 @@ jobs:
       ignore_missing_gateway: "false"
 
     hm:
-      director_account: {user: admin, password: admin}
+      director_account:
+        user: admin
+        password: (( secrets.hm_director_password ))
       resurrector_enabled: (( merge || "true" ))
 
     ntp: (( meta.ntp ))
@@ -123,10 +127,10 @@ jobs:
       http:
         # Variables used by official job release
         user: admin
-        password: admin
+        password: (( secrets.registry_password ))
       # Variables used by Google job release
       username: admin
-      password: admin
+      password: (( secrets.registry_password ))
 
     dns: (( merge || meta.default_dns ))
 

--- a/manifests/templates/bosh/bosh-template.yml
+++ b/manifests/templates/bosh/bosh-template.yml
@@ -110,6 +110,11 @@ jobs:
       cpi_job: cpi
       max_threads: 10
       ignore_missing_gateway: "false"
+      user_management:
+        provider: local
+        local:
+          users:
+            - { name: admin, password: (( secrets.bosh_admin_password )) }
 
     hm:
       director_account:

--- a/manifests/templates/bosh/bosh-template.yml
+++ b/manifests/templates/bosh/bosh-template.yml
@@ -30,7 +30,7 @@ meta:
   postgres:
     host: 127.0.0.1
     user: postgres
-    password: (( secrets.postgres_password ))
+    password: (( secrets.bosh_postgres_password ))
     database: bosh
     adapter: postgres
 
@@ -41,7 +41,7 @@ meta:
     recursor: 8.8.8.8
 
   default_agent:
-    mbus: (( "nats://nats:" secrets.nats_password "@" meta.bosh_service_ip ":4222" ))
+    mbus: (( "nats://nats:" secrets.bosh_nats_password "@" meta.bosh_service_ip ":4222" ))
 
 name: (( merge ))
 
@@ -80,12 +80,12 @@ jobs:
     nats:
       address: 127.0.0.1
       user: nats
-      password: (( secrets.nats_password ))
+      password: (( secrets.bosh_nats_password ))
 
     redis:
       listen_address: 127.0.0.1
       address: 127.0.0.1
-      password: (( secrets.redis_password ))
+      password: (( secrets.bosh_redis_password ))
 
     postgres: (( meta.postgres ))
 
@@ -94,14 +94,14 @@ jobs:
       provider: dav
       director:
         user: director
-        password: (( secrets.blobstore_director_password ))
+        password: (( secrets.bosh_blobstore_director_password ))
       agent:
         user: agent
-        password: (( secrets.agent_password ))
+        password: (( secrets.bosh_agent_password ))
       options:
         endpoint: (( "http://" meta.bosh_public_ip ":25250" ))
         user: agent
-        password: (( secrets.agent_password ))
+        password: (( secrets.bosh_agent_password ))
 
     director:
       address: 127.0.0.1
@@ -114,7 +114,7 @@ jobs:
     hm:
       director_account:
         user: admin
-        password: (( secrets.hm_director_password ))
+        password: (( secrets.bosh_hm_director_password ))
       resurrector_enabled: (( merge || "true" ))
 
     ntp: (( meta.ntp ))
@@ -127,10 +127,10 @@ jobs:
       http:
         # Variables used by official job release
         user: admin
-        password: (( secrets.registry_password ))
+        password: (( secrets.bosh_registry_password ))
       # Variables used by Google job release
       username: admin
-      password: (( secrets.registry_password ))
+      password: (( secrets.bosh_registry_password ))
 
     dns: (( merge || meta.default_dns ))
 

--- a/manifests/templates/deployments/postgres.yml
+++ b/manifests/templates/deployments/postgres.yml
@@ -1,3 +1,4 @@
+secrets: (( merge ))
 jobs:
 - <<: (( merge ))
 - name: postgres
@@ -19,7 +20,7 @@ jobs:
       roles:
         - tag: admin
           name: admin
-          password: (( merge ))
+          password: (( secrets.postgres_password ))
           permissions:
             - SUPERUSER
             - INHERIT

--- a/manifests/templates/deployments/postgres.yml
+++ b/manifests/templates/deployments/postgres.yml
@@ -18,8 +18,8 @@ jobs:
       log_line_prefix: "psql %m:"
       roles:
         - tag: admin
-          name: (( merge || "admin" ))
-          password: (( merge || "administrator" ))
+          name: admin
+          password: (( merge ))
           permissions:
             - SUPERUSER
             - INHERIT

--- a/manifests/templates/gce/bosh/bosh-manifest.yml
+++ b/manifests/templates/gce/bosh/bosh-manifest.yml
@@ -71,9 +71,9 @@ jobs:
       blobstore:
         options:
           endpoint: (( "http://" meta.bosh_service_ip ":25250" ))
-          password: (( secrets.agent_password ))
+          password: (( secrets.bosh_agent_password ))
           user: agent
-      mbus: (( "nats://nats:" secrets.nats_password "@" meta.bosh_service_ip ":4222" ))
+      mbus: (( "nats://nats:" secrets.bosh_nats_password "@" meta.bosh_service_ip ":4222" ))
       ntp: (( meta.ntp ))
 
     ntp: (( meta.ntp ))

--- a/manifests/templates/gce/bosh/bosh-manifest.yml
+++ b/manifests/templates/gce/bosh/bosh-manifest.yml
@@ -1,4 +1,5 @@
 ---
+secrets: (( merge ))
 terraform_outputs: (( merge ))
 
 meta:
@@ -70,9 +71,9 @@ jobs:
       blobstore:
         options:
           endpoint: (( "http://" meta.bosh_service_ip ":25250" ))
-          password: agent-password
+          password: (( secrets.agent_password ))
           user: agent
-      mbus: (( "nats://nats:nats-password@" meta.bosh_service_ip ":4222" ))
+      mbus: (( "nats://nats:" secrets.nats_password "@" meta.bosh_service_ip ":4222" ))
       ntp: (( meta.ntp ))
 
     ntp: (( meta.ntp ))

--- a/manifests/templates/gce/stubs/cf-stub-gce.yml
+++ b/manifests/templates/gce/stubs/cf-stub-gce.yml
@@ -1,5 +1,6 @@
 ---
 terraform_outputs: ((merge))
+secrets: (( merge ))
 name: (( merge ))
 meta:
   <<: (( merge ))
@@ -69,7 +70,7 @@ properties:
     roles:
       - tag: admin
         name: ccadmin
-        password: (( merge ))
+        password: (( secrets.ccadmin_password ))
     databases:
       - tag: cc
         name: ccdb
@@ -82,7 +83,7 @@ properties:
     roles:
       - tag: admin
         name: uaaadmin
-        password: (( merge ))
+        password: (( secrets.uuadmin_password ))
     databases:
       - tag: uaa
         name: uaadb
@@ -95,10 +96,10 @@ properties:
     roles:
       - tag: admin
         name: ccadmin
-        password: (( merge ))
+        password: (( secrets.ccadmin_password ))
       - tag: admin
         name: uaaadmin
-        password: (( merge ))
+        password: (( secrets.uuadmin_password ))
     databases:
       - tag: cc
         name: ccdb

--- a/manifests/templates/gce/stubs/cf-stub-gce.yml
+++ b/manifests/templates/gce/stubs/cf-stub-gce.yml
@@ -69,7 +69,7 @@ properties:
     roles:
       - tag: admin
         name: ccadmin
-        password: admin
+        password: (( merge ))
     databases:
       - tag: cc
         name: ccdb
@@ -82,7 +82,7 @@ properties:
     roles:
       - tag: admin
         name: uaaadmin
-        password: admin
+        password: (( merge ))
     databases:
       - tag: uaa
         name: uaadb
@@ -95,10 +95,10 @@ properties:
     roles:
       - tag: admin
         name: ccadmin
-        password: admin
+        password: (( merge ))
       - tag: admin
         name: uaaadmin
-        password: admin
+        password: (( merge ))
     databases:
       - tag: cc
         name: ccdb

--- a/manifests/templates/stubs/cf-stub.yml
+++ b/manifests/templates/stubs/cf-stub.yml
@@ -20,127 +20,21 @@ jobs:
 properties:
   cc:
     staging_upload_user: username
-    staging_upload_password: password
-    bulk_api_password: password
-    db_encryption_key: the_key
     min_cli_version: '6.1.0'
     min_recommended_cli_version: '6.10.0'
+  nats:
+    user: nats_user
   dea_next:
     disk_mb: 10240
     memory_mb: 4096
-  nats:
-    user: nats_user
-    password: nats_password
   router:
     enable_ssl: true
-    ssl_cert: |
-      -----BEGIN CERTIFICATE-----
-      MIIDBjCCAe4CCQCz3nn1SWrDdTANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJB
-      VTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0
-      cyBQdHkgTHRkMB4XDTE1MDMwMzE4NTMyNloXDTE2MDMwMjE4NTMyNlowRTELMAkG
-      A1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0
-      IFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-      AKtTK9xq/ycRO3fWbk1abunYf9CY6sl0Wlqm9UPMkI4j0itY2OyGyn1YuCCiEdM3
-      b8guGSWB0XSL5PBq33e7ioiaH98UEe+Ai+TBxnJsro5WQ/TMywzRDhZ4E7gxDBav
-      88ZY+y7ts0HznfxqEIn0Gu/UK+s6ajYcIy7d9L988+hA3K1FSdes8MavXhrI4xA1
-      fY21gESfFkD4SsqvrkISC012pa7oVw1f94slIVcAG+l9MMAkatBGxgWAQO6kxk5o
-      oH1Z5q2m0afeQBfFqzu5lCITLfgTWCUZUmbF6UpRhmD850/LqNtryAPrLLqXxdig
-      OHiWqvFpCusOu/4z1uGC5xECAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAV5RAFVQy
-      8Krs5c9ebYRseXO6czL9/Rfrt/weiC1XLcDkE2i2yYsBXazMYr58o4hACJwe2hoC
-      bihBZ9XnVpASEYHDLwDj3zxFP/bTuKs7tLhP7wz0lo8i6k5VSPAGBq2kjc/cO9a3
-      TMmLPks/Xm42MCSWGDnCEX1854B3+JK3CNEGqSY7FYXU4W9pZtHPZ3gBoy0ymSpg
-      mpleiY1Tbn5I2X7vviMW7jeviB5ivkZaXtObjyM3vtPLB+ILpa15ZhDSE5o71sjA
-      jXqrE1n5o/GXHX+1M8v3aJc30Az7QAqWohW/tw5SoiSmVQZWd7gFht9vSzaH2WgO
-      LwcpBC7+cUJEww==
-      -----END CERTIFICATE-----
-    ssl_key: |
-      -----BEGIN RSA PRIVATE KEY-----
-      MIIEpAIBAAKCAQEAq1Mr3Gr/JxE7d9ZuTVpu6dh/0JjqyXRaWqb1Q8yQjiPSK1jY
-      7IbKfVi4IKIR0zdvyC4ZJYHRdIvk8Grfd7uKiJof3xQR74CL5MHGcmyujlZD9MzL
-      DNEOFngTuDEMFq/zxlj7Lu2zQfOd/GoQifQa79Qr6zpqNhwjLt30v3zz6EDcrUVJ
-      16zwxq9eGsjjEDV9jbWARJ8WQPhKyq+uQhILTXalruhXDV/3iyUhVwAb6X0wwCRq
-      0EbGBYBA7qTGTmigfVnmrabRp95AF8WrO7mUIhMt+BNYJRlSZsXpSlGGYPznT8uo
-      22vIA+ssupfF2KA4eJaq8WkK6w67/jPW4YLnEQIDAQABAoIBAQCDVqpcOoZKK9K8
-      Bt3eXQKEMJ2ji2cKczFFJ5MEm9EBtoJLCryZbqfSue3Fzpj9pBUEkBpk/4VT5F7o
-      0/Vmc5Y7LHRcbqVlRtV30/lPBPQ4V/eWtly/AZDcNsdfP/J1fgPSvaoqCr2ORLWL
-      qL/vEfyIeM4GcWy0+JMcPbmABslw9O6Ptc5RGiP98vCLHQh/++sOtj6PH1pt+2X/
-      Uecv3b1Hk/3Oe+M8ySorJD3KA94QTRnKX+zubkxRg/zCAki+as8rQc/d+BfVG698
-      ylUT5LVLNuwbWnffY2Zt5x5CDqH01mJnHmxzQEfn68rb3bGFaYPEn9EP+maQijv6
-      SsUM9A3lAoGBAODRDRn4gEIxjPICp6aawRrMDlRc+k6IWDF7wudjxJlaxFr2t7FF
-      rFYm+jrcG6qMTyq+teR8uHpcKm9X8ax0L6N6gw5rVzIeIOGma/ZuYIYXX2XJx5SW
-      SOas1xW6qEIbOMv+Xu9w2SWbhTgyRmtlxxjr2e7gQLz9z/vuTReJpInnAoGBAMMW
-      sq5lqUfAQzqxlhTobQ7tnB48rUQvkGPE92SlDj2TUt9phek2/TgRJT6mdcozvimt
-      JPhxKg3ioxG8NPmN0EytjpSiKqlxS1R2po0fb75vputfpw16Z8/2Vik+xYqNMTLo
-      SpeVkHu7fbtNYEK2qcU44OyOZ/V+5Oo9TuBIFRhHAoGACkqHhwDRHjaWdR2Z/w5m
-      eIuOvF3lN2MWZm175ouynDKDeoaAsiS2VttB6R/aRFxX42UHfoYXC8LcTmyAK5zF
-      8X3SMf7H5wtqBepQVt+Gm5zGSSqLcEnQ3H5c+impOh105CGoxt0rk4Ui/AeRIalv
-      C70AJOcvD3eu5aFq9gDe/1ECgYBAhkVbASzYGnMh+pKVH7rScSxto8v6/XBYT1Ez
-      7JOlMhD667/qvtFJtgIHkq7qzepbhnTv5x3tscQVnZY34/u9ILpD1s8dc+dibEvx
-      6S/gYLVorB5ois/DLMqaobRcew6Gs+XX9RPwmLahOJpZ9mh4XrOmCgPAYtP71YM9
-      ExpHCQKBgQCMMDDWGMRdFMJgXbx1uMere7OoniBdZaOexjbglRh1rMVSXqzBoU8+
-      yhEuHGAsHGWQdSBHnqRe9O0Bj/Vlw2VVEaJeL1ewRHb+jXSnuKclZOJgMsJAvgGm
-      SOWIahDrATA4g1T6yLBWQPhj3ZXD3eCMxT1Q3DvpG1DjgvXwmXQJAA==
-      -----END RSA PRIVATE KEY-----
     cipher_suites: TLS_RSA_WITH_RC4_128_SHA:TLS_RSA_WITH_AES_128_CBC_SHA
     status:
       user: router_user
-      password: router_password
   uaa:
-    admin:
-      client_secret: admin_secret
     batch:
       username: batch_username
-      password: batch_password
-    cc:
-      client_secret: cc_client_secret
-    clients:
-      app-direct:
-        secret: app-direct_secret
-      developer_console:
-        secret: developer_console_secret
-      login:
-        secret: login_client_secret
-      notifications:
-        secret: notification_secret
-      doppler:
-        secret: doppler_secret
-      cloud_controller_username_lookup:
-        secret: cloud_controller_username_lookup_secret
-      gorouter:
-        secret: gorouter_secret
-
-
-    jwt:
-      signing_key: |
-        -----BEGIN RSA PRIVATE KEY-----
-        MIICXAIBAAKBgQDHFr+KICms+tuT1OXJwhCUmR2dKVy7psa8xzElSyzqx7oJyfJ1
-        JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMXqHxf+ZH9BL1gk9Y6kCnbM5R6
-        0gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBugspULZVNRxq7veq/fzwIDAQAB
-        AoGBAJ8dRTQFhIllbHx4GLbpTQsWXJ6w4hZvskJKCLM/o8R4n+0W45pQ1xEiYKdA
-        Z/DRcnjltylRImBD8XuLL8iYOQSZXNMb1h3g5/UGbUXLmCgQLOUUlnYt34QOQm+0
-        KvUqfMSFBbKMsYBAoQmNdTHBaz3dZa8ON9hh/f5TT8u0OWNRAkEA5opzsIXv+52J
-        duc1VGyX3SwlxiE2dStW8wZqGiuLH142n6MKnkLU4ctNLiclw6BZePXFZYIK+AkE
-        xQ+k16je5QJBAN0TIKMPWIbbHVr5rkdUqOyezlFFWYOwnMmw/BKa1d3zp54VP/P8
-        +5aQ2d4sMoKEOfdWH7UqMe3FszfYFvSu5KMCQFMYeFaaEEP7Jn8rGzfQ5HQd44ek
-        lQJqmq6CE2BXbY/i34FuvPcKU70HEEygY6Y9d8J3o6zQ0K9SYNu+pcXt4lkCQA3h
-        jJQQe5uEGJTExqed7jllQ0khFJzLMx0K6tj0NeeIzAaGCQz13oo2sCdeGRHO4aDh
-        HH6Qlq/6UOV5wP8+GAcCQFgRCcB+hrje8hfEEefHcFpyKH+5g1Eu1k0mLrxK2zd+
-        4SlotYRHgPCEubokb2S1zfZDWIXW3HmggnGgM949TlY=
-        -----END RSA PRIVATE KEY-----
-
-      verification_key: |
-        -----BEGIN PUBLIC KEY-----
-        MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHFr+KICms+tuT1OXJwhCUmR2d
-        KVy7psa8xzElSyzqx7oJyfJ1JZyOzToj9T5SfTIq396agbHJWVfYphNahvZ/7uMX
-        qHxf+ZH9BL1gk9Y6kCnbM5R60gfwjyW1/dQPjOzn9N394zd2FJoFHwdq9Qs0wBug
-        spULZVNRxq7veq/fzwIDAQAB
-        -----END PUBLIC KEY-----
-
-    scim:
-      users:
-      - admin|fakepassword|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose
-  loggregator_endpoint:
-    shared_secret: secret
   login:
     links:
       network: https://network.gopivotal.com/login

--- a/manifests/templates/stubs/cf-stub.yml
+++ b/manifests/templates/stubs/cf-stub.yml
@@ -1,9 +1,14 @@
 ---
 terraform_outputs: ((merge))
+secrets: (( merge ))
+
 director_uuid: BOSH_UUID
 name: (( "cloudfoundry-" meta.environment ))
 meta:
   environment: (( terraform_outputs.environment ))
+  default_env:
+    bosh:
+      password: (( secrets.vcap_password ))
 
 update:
   serial: false # makes every job deploy at the same time.
@@ -20,21 +25,55 @@ jobs:
 properties:
   cc:
     staging_upload_user: username
+    staging_upload_password: (( secrets.staging_upload_password ))
+    bulk_api_password: (( secrets.bulk_api_password ))
+    db_encryption_key: (( secrets.cc_db_encryption_key ))
     min_cli_version: '6.1.0'
     min_recommended_cli_version: '6.10.0'
   nats:
     user: nats_user
+    password: (( secrets.nats_password ))
   dea_next:
     disk_mb: 10240
     memory_mb: 4096
   router:
     enable_ssl: true
+    ssl_cert: (( secrets.router_ssl_cert ))
+    ssl_key: (( secrets.router_ssl_key ))
     cipher_suites: TLS_RSA_WITH_RC4_128_SHA:TLS_RSA_WITH_AES_128_CBC_SHA
     status:
       user: router_user
+      password: (( secrets.router_password ))
   uaa:
+    admin:
+      client_secret: (( secrets.uaa_admin_client_secret ))
     batch:
       username: batch_username
+      password: (( secrets.uaa_batch_password ))
+    cc:
+      client_secret: (( secrets.uaa_cc_client_secret ))
+    clients:
+      app-direct:
+        secret: (( secrets.uaa_clients_app_direct_secret ))
+      developer_console:
+        secret: (( secrets.uaa_clients_developer_console_secret ))
+      login:
+        secret: (( secrets.uaa_clients_login_secret ))
+      notifications:
+        secret: (( secrets.uaa_clients_notifications_secret ))
+      doppler:
+        secret: (( secrets.uaa_clients_doppler_secret ))
+      cloud_controller_username_lookup:
+        secret: (( secrets.uaa_clients_cloud_controller_username_lookup_secret ))
+      gorouter:
+        secret: (( secrets.uaa_clients_gorouter_secret ))
+    jwt:
+      signing_key: (( secrets.uaa_jwt_signing_key ))
+      verification_key: (( secrets.uaa_jwt_verification_key ))
+    scim:
+      users:
+      - (( "admin|" secrets.uaa_admin_password "|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose" ))
+
   login:
     links:
       network: https://network.gopivotal.com/login
@@ -42,3 +81,6 @@ properties:
     smtp:
       host: localhost
       port: 2525
+
+  loggregator_endpoint:
+    shared_secret: (( secrets.loggregator_endpoint_shared_secret ))

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -259,7 +259,9 @@ cf_deploy() {
 
 cf_post_deploy() {
   # Deploy psql broker
-  time bash $SCRIPT_DIR/deploy_psql_broker.sh admin $(get_cf_secret secrets/uaa_admin_password)
+  time bash $SCRIPT_DIR/deploy_psql_broker.sh \
+    admin $(get_cf_secret secrets/uaa_admin_password) \
+    admin $(get_cf_secret secrets/postgres_password)
 }
 
 install_dependencies

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -4,6 +4,10 @@ set -e # fail on error
 
 SCRIPT_DIR=$(cd $(dirname $0) && pwd)
 
+get_cf_secret() { ${SCRIPT_DIR}/val_from_yaml.rb templates/cf-secrets.yml $1; }
+get_bosh_secret() { ${SCRIPT_DIR}/val_from_yaml.rb templates/bosh-secrets.yml $1; }
+get_output() { ${SCRIPT_DIR}/val_from_yaml.rb templates/outputs/terraform-outputs-${TARGET_PLATFORM}.yml $1; }
+
 # Read the platform configuration
 TARGET_PLATFORM=$1
 case $TARGET_PLATFORM in
@@ -27,7 +31,6 @@ esac
 . $SCRIPT_DIR/terraform-outputs-${TARGET_PLATFORM}.sh
 
 BOSH_ADMIN_USER=${BOSH_ADMIN_USER:-admin}
-BOSH_ADMIN_PASS=${BOSH_ADMIN_USER:-admin}
 BOSH_IP=${BOSH_IP:-$terraform_output_bosh_ip}
 BOSH_PORT=${BOSH_PORT:-25555}
 
@@ -114,9 +117,12 @@ function install_dependencies {
 
 # Bosh
 bosh_login() {
+  BOSH_ADMIN_PASS=$(get_bosh_secret secrets/bosh_admin_password)
   echo "Login to bosh $BOSH_IP:$BOSH_PORT"
   echo -e "${BOSH_ADMIN_USER}\n${BOSH_ADMIN_PASS}" | \
-    $BOSH_CLI target $BOSH_IP:$BOSH_PORT
+    $BOSH_CLI target $BOSH_IP:$BOSH_PORT || return 1
+  echo -e "${BOSH_ADMIN_USER}\n${BOSH_ADMIN_PASS}" | \
+    $BOSH_CLI login
 }
 
 bosh_check_and_login() {
@@ -253,7 +259,7 @@ cf_deploy() {
 
 cf_post_deploy() {
   # Deploy psql broker
-  time bash $SCRIPT_DIR/deploy_psql_broker.sh admin fakepassword
+  time bash $SCRIPT_DIR/deploy_psql_broker.sh admin $(get_cf_secret secrets/uaa_admin_password)
 }
 
 install_dependencies

--- a/scripts/val_from_yaml.rb
+++ b/scripts/val_from_yaml.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+filename = ARGV[0]
+path = ARGV[1]
+
+def get(hash, path_array)
+	unless path_array.empty?
+		get(hash[path_array[0]], path_array[1..-1])
+	else
+		hash
+	end
+end
+
+secrets_hash = YAML.load_file(filename)
+path_array = path.split('/')
+puts get(secrets_hash, path_array)


### PR DESCRIPTION
## What
- Externalise all secrets (passwords, keys, certificates...) from:
  - Cloud Foundry
  - BOSH
  - Terraform
- Override defaults from BOSH and cf-release:
  - BOSH admin user
  - vcap and root unix passwords
- Store encrypted passwords in a secure place. This depends on the [credentials PR](https://github.gds/multicloudpaas/credentials/pull/12)
- Generate manifests locally and upload to bastion
- Avoid storing clear text passwords locally
- Refactor manifests to be easy to maintain
- Ruby script helper to read secrets stored in YAML from bash scripts
## How to review
- _paas-pass_ _must_ be available in `~/.paas-pass`. It can be the repository or a link to it
- Requires the [credentials PR](https://github.gds/multicloudpaas/credentials/pull/12)
- Build a brand new environment. You could run on an existing environment, in theory it will recreate BOSH and reuse could foundry but it's risky
- Check the passwords are not default (Ex: bosh and cloud foundry ones)
- You could test the whole process of updating a password in paas-pass and redeploy
## Notes
- This has only been tested on GCE but it _should not_ make a difference
- From now on, be careful when sharing code, config or logs as it may contain our passwords
## Who can review

Anyone but @saliceti, @keymon or @dcarley 
