### PR TITLE
[#103419194] Use NAT to secure CF installation on GCE

### DIFF
--- a/gce/bastion.tf
+++ b/gce/bastion.tf
@@ -42,4 +42,9 @@ resource "google_compute_instance" "bastion" {
       "chmod 400 /home/ubuntu/.ssh/id_rsa"
     ]
   }
+
+  provisioner "remote-exec" {
+    script = "../scripts/setup-nat-routing.sh"
+  }
+
 }

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -12,6 +12,25 @@ resource "google_compute_firewall" "ssh" {
   }
 }
 
+resource "google_compute_firewall" "bosh" {
+  name = "${var.env}-cf-bosh"
+  description = "Allow bosh deployed vms to route via bastion"
+  network = "${google_compute_network.bastion.name}"
+
+  source_tags = [ "cf" ,"bastion", "bosh"]
+  target_tags = [ "bastion", "cf", "bosh" ]
+
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
+  }
+  allow {
+    protocol = "icmp"
+  }
+}
+
 # TODO: restrict better, currently opening all for convenience; known ports that need to be open:
 # TCP: 4222, 6868, 25250, 25555, 25777
 # UDP: 52, 3457

--- a/gce/network.tf
+++ b/gce/network.tf
@@ -6,3 +6,13 @@ resource "google_compute_network" "bastion" {
 resource "google_compute_address" "bosh" {
     name = "${var.env}-bosh"
 }
+
+resource "google_compute_route" "private_default" {
+  name = "${var.env}-private-default"
+  dest_range = "0.0.0.0/0"
+  network = "${google_compute_network.bastion.name}"
+  next_hop_instance = "${google_compute_instance.bastion.name}"
+  next_hop_instance_zone = "${google_compute_instance.bastion.zone}"
+  priority = 1
+  tags = [ "cf" ]
+}

--- a/manifests/templates/gce/stubs/cf-stub-gce.yml
+++ b/manifests/templates/gce/stubs/cf-stub-gce.yml
@@ -17,9 +17,9 @@ networks:
     type: dynamic
     cloud_properties:
       network_name: (( terraform_outputs.cf1_network_name ))
-      ephemeral_external_ip: true
+      ephemeral_external_ip: false
       tags:
-        - bosh
+        - cf
         - (( terraform_outputs.environment ))
         - (( name ))
 
@@ -27,9 +27,9 @@ networks:
     type: dynamic
     cloud_properties:
       network_name: (( terraform_outputs.cf2_network_name ))
-      ephemeral_external_ip: true
+      ephemeral_external_ip: false
       tags:
-        - bosh
+        - cf
         - (( terraform_outputs.environment ))
         - (( name ))
 
@@ -37,9 +37,9 @@ networks:
     type: dynamic
     cloud_properties:
       network_name: (( terraform_outputs.cf1_network_name ))
-      ephemeral_external_ip: true
+      ephemeral_external_ip: false
       tags:
-        - bosh
+        - cf
         - (( terraform_outputs.environment ))
         - (( name ))
       target_pool: (( terraform_outputs.router_pool_name ))
@@ -48,9 +48,9 @@ networks:
     type: dynamic
     cloud_properties:
       network_name: (( terraform_outputs.cf2_network_name ))
-      ephemeral_external_ip: true
+      ephemeral_external_ip: false
       tags:
-        - bosh
+        - cf
         - (( terraform_outputs.environment ))
         - (( name ))
       target_pool: (( terraform_outputs.router_pool_name ))

--- a/manifests/templates/gce/stubs/cf-stub-gce.yml
+++ b/manifests/templates/gce/stubs/cf-stub-gce.yml
@@ -62,6 +62,9 @@ properties:
       availability_zone: (( terraform_outputs.zone0 ))
       availability_zone2: (( terraform_outputs.zone1 ))
 
+  dea_next:
+    mtu: 1460
+
   ccdb:
     db_scheme: postgres
     address: (( properties.databases.address ))

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -34,7 +34,7 @@ BOSH_PORT=${BOSH_PORT:-25555}
 # Git cf-release to clone
 CF_RELEASE=215
 CF_RELEASE_GIT_URL=https://github.com/alphagov/cf-release.git
-CF_RELEASE_REVISION=cf_jobs_without_static_ips_dependencies_v215
+CF_RELEASE_REVISION='cf_jobs_without_static_ips_dependencies_v215_103419194_with_dea_next_mtu'
 
 # Releases to upload
 BOSH_RELEASES="


### PR DESCRIPTION
[Use NAT to secure CF installation](https://www.pivotaltracker.com/story/show/103419194)

**What**
- I do not want my private Cloud Foundry VMs to have public ip addresses
- I also do not want green eggs and ham.

**How to review this PR**

This PR has been written with the following narrative:
- I want set up IP masquerading on the bastion so I can route internet traffic through it
- I want to turn off public mapping of IP address and set the default route to be via the bastion box by doing:
  - Disabling public IP mapping for each Cloud Foundry Virtual Machine
  - Setting the default route for all CF VMs to be via bastion instance
  - Creating a firewall rule to allow bosh deployed CF vms to route via bastion
  - Changing the tag for CF VMs to be `cf` instead of `bosh` because
    we use DNAT for the microbosh to allow routing to bastion and this
    will not work if the routing rule is applied to bosh
- I want to sett the MTU to be 1460 in the warden containers to match
  the MTU on the runner VMs

**How to test this PR**

To test this PR launch an GCE environment and confirm in the `GCE Console` that only bosh and bastion have public IP addresses.

```
make gce DEPLOY_ENV=$SAM_I_AM
```

Test deploying an application (spring music for example) and confirm that everything works as expected.

**Who should review and merge this PR**
- Anyone on the on the main team except @jimconner or I since...
  - I would not merge it on a boat
  - I would not merge it with a goat
  - I would not merge it in the rain
  - I would not merge it on a train
