### PR TITLE
[#103408418] Improve Cloud Foundry build speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ To provision a microbosh instance on AWS and GCE.
 In order to deploy a microbosh, it is necessary to first create subnets, security groups and static IP reservations which will be used by bosh-init when deploying the microbosh. We are using terraform to create these resources, along with a bastion host which will perform the actual `bosh-init` steps to create the microbosh.
 
 ##Pre-requisites
+
 * You will need to be running ssh-agent and have performed an `ssh-add <deployer_key>` to make the credentials available for ssh to be able to connect into the bastion host
+* You need to have the [team password store `paas-pass` setup](https://github.gds/multicloudpaas/credentials)
 * Make available the ssh directory inside aws and gce
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,13 +19,28 @@ gce/
         insecure-deployer.pub
 ```
 * Provide `account.json` inside gce
-* Provide AWS access keys as environment variables, plus the corresponding terraform variables. Example in profile:
+* On AWS: Provide AWS access keys as environment variables, plus the corresponding terraform variables. Example in profile:
 
 ```
 export AWS_ACCESS_KEY_ID=XXXXXXXXXX
 export AWS_SECRET_ACCESS_KEY=YYYYYYYYYY
 export TF_VAR_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 export TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+```
+
+* On GCE: Provide GCE developers access keys to access GCS in interoperability
+  mode for compiled package cache, [as described here](https://cloud.google.com/storage/docs/migrating)
+```
+export TF_VAR_GCE_INTEROPERABILITY_ACCESS_KEY_ID=YYYYYYYYYYY
+export TF_VAR_GCE_INTEROPERABILITY_SECRET_ACCESS_KEY=XXXXXXXXXX
+```
+
+Note: Optionally it is possible to use the AWS compile cache bucket by setting:
+
+```
+export TF_VAR_GCE_INTEROPERABILITY_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+export TF_VAR_GCE_INTEROPERABILITY_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+export TF_VAR_GCE_INTEROPERABILITY_HOST=s3-eu-west-1.amazonaws.com
 ```
 
 ##Usage

--- a/README.md
+++ b/README.md
@@ -28,14 +28,8 @@ export TF_VAR_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 export TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 ```
 
-* On GCE: Provide GCE developers access keys to access GCS in interoperability
-  mode for compiled package cache, [as described here](https://cloud.google.com/storage/docs/migrating)
-```
-export TF_VAR_GCE_INTEROPERABILITY_ACCESS_KEY_ID=YYYYYYYYYYY
-export TF_VAR_GCE_INTEROPERABILITY_SECRET_ACCESS_KEY=XXXXXXXXXX
-```
-
-Note: Optionally it is possible to use the AWS compile cache bucket by setting:
+* On GCE: Pass the AWS credentials to access the shared compile package bucket
+  on AWS using the following variables. Specify also the AWS host with the zone.
 
 ```
 export TF_VAR_GCE_INTEROPERABILITY_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
@@ -79,3 +73,26 @@ gcloud compute instances reset --zone europe-west1-b vm-10ced236-8fd0-4274-4f51-
 
 Otherwise, letting it timeout and reruning the `make` command, it will rerun the `bosh-init` which
 will delete the old VM and create a new one. Repeat this step until one works :)
+
+Known issues
+============
+
+GCS with operability mode for compiled packages on GCE
+-------------------------------------------------------
+
+On GCE we tried using the GCS in interoperability
+mode for compiled package cache, [as described here](https://cloud.google.com/storage/docs/migrating)
+
+```
+export TF_VAR_GCE_INTEROPERABILITY_ACCESS_KEY_ID=YYYYYYYYYYY
+export TF_VAR_GCE_INTEROPERABILITY_SECRET_ACCESS_KEY=XXXXXXXXXX
+export TF_VAR_GCE_INTEROPERABILITY_HOST=storage.googleapi.com
+```
+
+But we got random errors using it, like:
+
+```
+Failed compiling packages > java/1dab29614aba5dcec2bc03c1dd7c06ad2e803212: Failed to create object, S3 response error: The request signature we calculated does not match the signature you provided. Check your Google secret key and signing method. (00:01:38)
+```
+
+As this does not affect the evaluation, we will just use S3 AWS for the time being.

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -34,14 +34,6 @@ output "cf2_subnet_id" {
 	value = "${aws_subnet.cf.1.id}"
 }
 
-output "aws_secret_access_key" {
-	value = "${var.AWS_SECRET_ACCESS_KEY}"
-}
-
-output "aws_access_key_id" {
-	value = "${var.AWS_ACCESS_KEY_ID}"
-}
-
 output "ccdb_address" {
 	value = "${aws_db_instance.ccdb.address}"
 }
@@ -96,4 +88,24 @@ output "microbosh_static_public_ip" {
 
 output "key_pair_name" {
 	value = "${var.key_pair_name}"
+}
+
+output "aws_secret_access_key" {
+	value = "${var.AWS_SECRET_ACCESS_KEY}"
+}
+
+output "aws_access_key_id" {
+       value = "${var.AWS_ACCESS_KEY_ID}"
+}
+
+output "compiled_cache_bucket_access_key_id" {
+	value = "${var.AWS_ACCESS_KEY_ID}"
+}
+
+output "compiled_cache_bucket_secret_access_key" {
+	value = "${var.AWS_SECRET_ACCESS_KEY}"
+}
+
+output "compiled_cache_bucket_host" {
+	value = "s3-${var.region}.amazonaws.com"
 }

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -55,3 +55,14 @@ output "gce_account_json" {
 #	value = "${replace(file("account.json"), "\n", "")}"
 }
 
+output "compiled_cache_bucket_access_key_id" {
+	value = "${var.GCE_INTEROPERABILITY_ACCESS_KEY_ID}"
+}
+
+output "compiled_cache_bucket_secret_access_key" {
+	value = "${var.GCE_INTEROPERABILITY_SECRET_ACCESS_KEY}"
+}
+
+output "compiled_cache_bucket_host" {
+	value = "${var.GCE_INTEROPERABILITY_HOST}"
+}

--- a/gce/variables.tf
+++ b/gce/variables.tf
@@ -56,3 +56,22 @@ variable "dns_zone_name" {
   description = "Google DNS zone name"
   default     = "cf2.paas.alphagov.co.uk"
 }
+
+# Terraform currently only has limited support for reading environment variables
+# Variables for use with terraform must be prefexed with 'TF_VAR_'
+# These two variables are passed in as environment variables named:
+# TF_VAR_GCE_INTEROPERABILITY_ACCESS_KEY_ID and
+# TF_VAR_GCE_INTEROPERABILITY_SECRET_ACCESS_KEY respectively
+variable "GCE_INTEROPERABILITY_ACCESS_KEY_ID" {
+  description = "GCE interoperability access key to be pass to access buckets"
+}
+
+variable "GCE_INTEROPERABILITY_SECRET_ACCESS_KEY" {
+  description = "GCE interoperability secret access key to be pass to access buckets"
+}
+
+variable "GCE_INTEROPERABILITY_HOST" {
+  description = "GCE interoperability host to access buckets"
+  default = "storage.googleapis.com"
+}
+

--- a/manifests/templates/aws/bosh/bosh-manifest.yml
+++ b/manifests/templates/aws/bosh/bosh-manifest.yml
@@ -64,14 +64,6 @@ jobs:
 - name: bosh
 
   properties:
-    compiled_package_cache:
-      provider: s3
-      options:
-        access_key_id: (( terraform_outputs.aws_access_key_id ))
-        secret_access_key: (( terraform_outputs.aws_secret_access_key ))
-        bucket_name: shared-cf-bosh-blobstore
-        host: s3-eu-west-1.amazonaws.com
-
     hm:
       resurrector_enabled: true
 

--- a/manifests/templates/aws/bosh/bosh-manifest.yml
+++ b/manifests/templates/aws/bosh/bosh-manifest.yml
@@ -64,6 +64,14 @@ jobs:
 - name: bosh
 
   properties:
+    compiled_package_cache:
+      provider: s3
+      options:
+        access_key_id: (( terraform_outputs.aws_access_key_id ))
+        secret_access_key: (( terraform_outputs.aws_secret_access_key ))
+        bucket_name: shared-cf-bosh-blobstore
+        host: s3-eu-west-1.amazonaws.com
+
     hm:
       resurrector_enabled: true
 

--- a/manifests/templates/bosh/bosh-template.yml
+++ b/manifests/templates/bosh/bosh-template.yml
@@ -1,6 +1,6 @@
 ---
 secrets: (( merge ))
-
+terraform_outputs: (( merge ))
 meta:
   cpi-release: (( merge ))
 
@@ -77,6 +77,14 @@ jobs:
     static_ips: (( merge || meta.default_bosh_public_static_ips ))
 
   properties:
+    compiled_package_cache:
+      provider: s3
+      options:
+        access_key_id: (( terraform_outputs.compiled_cache_bucket_access_key_id ))
+        secret_access_key: (( terraform_outputs.compiled_cache_bucket_secret_access_key ))
+        bucket_name: shared-cf-bosh-blobstore
+        host: (( terraform_outputs.compiled_cache_bucket_host ))
+
     nats:
       address: 127.0.0.1
       user: nats


### PR DESCRIPTION
## What

Deployment of a full BOSH/CF environment takes too long. We identified the quickest and safest way to reduce build time, by using a shared cache on Amazon S3 for compiled packages. Other optimisations will be executed in separate stories.

A GCE environment should store the artefacts in S3 as well. We tested storing in GCS with S3 interoperability but we had some issues. Feel free to give GCS a try.
## How to review
- Create a full BOSH/CF environment using this configuration
- Delete CF deployment
- Delete CF release
- Deploy CF again. It should be much faster
## Who can review

Anyone but @saliceti or @keymon 
