### PR TITLE
[#103419194] Use NAT to secure CF installation on GCE

### DIFF
--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -31,9 +31,6 @@ resource "google_compute_firewall" "bosh" {
   }
 }
 
-# TODO: restrict better, currently opening all for convenience; known ports that need to be open:
-# TCP: 4222, 6868, 25250, 25555, 25777
-# UDP: 52, 3457
 resource "google_compute_firewall" "internal" {
   name = "${var.env}-cf-internal"
   description = "Open internal communication between instances"
@@ -46,9 +43,11 @@ resource "google_compute_firewall" "internal" {
 
   allow {
     protocol = "tcp"
+    ports = [ 22, 53, 4222, 6868, 25250, 25555, 25777 ]
   }
   allow {
     protocol = "udp"
+    ports = [ 53, 3457 ]
   }
 }
 


### PR DESCRIPTION
[Use NAT to secure CF installation](https://www.pivotaltracker.com/story/show/103419194)

**What**
- I want more restrictive firewall rules on communication to Bosh

**How to review this PR**

This PR has been written with the following narrative:
- I want the firewall ports listed in the TODO section to be applied to communications for Bosh 

**How to test this PR**

To test this PR launch an GCE environment and confirm that it deploys correctly and the ports for the <env>-internalbosh firewall rule are as expected. 
Confirm that the deployed CloudFoundry works as expected.

```
make gce DEPLOY_ENV=something
```

Test deploying an application (spring music for example) and confirm that everything works as expected.

**Who should review and merge this PR**
- Anyone on the on the main team except @jimconner 
