### PR TITLE
[#103408418] Change max_threads in BOSH to default value

### DIFF
--- a/manifests/templates/bosh/bosh-template.yml
+++ b/manifests/templates/bosh/bosh-template.yml
@@ -116,7 +116,6 @@ jobs:
       name: my-bosh
       db: (( meta.postgres ))
       cpi_job: cpi
-      max_threads: 10
       ignore_missing_gateway: "false"
       user_management:
         provider: local


### PR DESCRIPTION
## What

Deployment of a full BOSH/CF environment takes too long. 

One of the slowest steps is the creation of VMs. 

We are restricting the number of threads in BOSH in 10 threads (got that value from a example in internet). If we change back the value of the `max_threads` in [bosh to the default
value](https://github.com/cloudfoundry/bosh/blob/master/release/jobs/director/spec#L73)
which is currently 32., it will allow BOSH create more VMs in parallel, decreasing the total
time to deploy a complex environment like cloudfoundry.
## How to review

You **do not** need a fresh environment to test this. The best approach can be:
1. Redeploy bosh with (Note, in GCE you need to delete the static route first with `make delete-route-gce DEPLOY_ENV=....`)

```
make prepare-provision-aws DEPLOY_ENV=....
make ssh-aws DEPLOY_ENV=....

# now on the bastion:
./generate_bosh_manifest.sh aws > bosh-manifest.yml
bosh-init deploy  bosh-deployment.yml
```
1. Now try to delete the deployment (`bosh delete deployment cloudfoundry-....`) or redeploy cloudfoundry (`bosh deploy --recreate`). It should setup more  VMs in parallel.
## Who can review this

Anyone but @keymon
