### PR TITLE
[#104894544] Delete CF deployments without destroying BOSH

### DIFF
--- a/scripts/bosh_delete_deployments.rb
+++ b/scripts/bosh_delete_deployments.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require 'cli'
+
+bosh_cli = Bosh::Cli::Command::Base.new.director
+deployments = bosh_cli.list_deployments.map { |d| d["name"] }
+
+if deployments.empty?
+    puts "No deployments"
+    exit
+end
+
+puts "Deployments: #{deployments.join(', ')}"
+
+if ARGV[0] == "-y"
+    delete = true
+else
+    print "Delete all deployments? [yn] "
+    delete = true if gets.strip[0].downcase == 'y'
+end
+
+if delete
+    deployments.each { |d|
+        puts "Delete deployment #{d}"
+        bosh_cli.delete_deployment(d)
+    }
+end

--- a/scripts/deploy_cf.sh
+++ b/scripts/deploy_cf.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e # fail on error
+
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+
+get_cf_secret() { ${SCRIPT_DIR}/val_from_yaml.rb templates/cf-secrets.yml $1; }
+get_output() { ${SCRIPT_DIR}/val_from_yaml.rb templates/outputs/terraform-outputs-${TARGET_PLATFORM}.yml $1; }
+
+# Read the platform configuration
+TARGET_PLATFORM=$1
+case $TARGET_PLATFORM in
+  aws)
+    STEMCELL=light-bosh-stemcell-3074-aws-xen-hvm-ubuntu-trusty-go_agent.tgz
+    ;;
+  gce)
+    STEMCELL=light-bosh-stemcell-3074-google-kvm-ubuntu-trusty-go_agent.tgz
+    STEMCELL_URL=http://storage.googleapis.com/gce-bosh-stemcells/$STEMCELL
+    ;;
+  *)
+    echo "Must specify the target platform: gce|aws"
+    exit 1
+    ;;
+esac
+
+# Include the terraform output variables
+. $SCRIPT_DIR/terraform-outputs-${TARGET_PLATFORM}.sh
+
+export BUNDLE_GEMFILE=$SCRIPT_DIR/Gemfile
+BOSH_CLI="bundle exec bosh"
+
+# Other config
+export PATH=$PATH:/usr/local/bin
+
+cf_compile_manifest() {
+  # Use spiff to generate CF deployment manifest
+  cd ~
+
+  # Output the director uuid to be populated by spiff
+  echo -e "---\ndirector_uuid: $($BOSH_CLI status --uuid)" > templates/stubs/director-uuid.yml
+
+  # Generate the manifest
+  CF_RELEASE_PATH=~/cf-release/ ./generate_deployment_manifest.sh $TARGET_PLATFORM > ~/cf-manifest.yml
+}
+
+cf_deploy() {
+  $BOSH_CLI deployment ~/cf-manifest.yml
+  time $BOSH_CLI -n deploy
+}
+
+cf_post_deploy() {
+  # Deploy psql broker
+  time bash $SCRIPT_DIR/deploy_psql_broker.sh \
+    admin $(get_cf_secret secrets/uaa_admin_password) \
+    admin $(get_cf_secret secrets/postgres_password)
+}
+
+cf_compile_manifest
+cf_deploy
+cf_post_deploy

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -241,32 +241,6 @@ cf_prepare_deployment() {
   upload_releases
 }
 
-cf_compile_manifest() {
-  # Use spiff to generate CF deployment manifest
-  cd ~
-
-  # Output the director uuid to be populated by spiff
-  echo -e "---\ndirector_uuid: $($BOSH_CLI status --uuid)" > templates/stubs/director-uuid.yml
-
-  # Generate the manifest
-  CF_RELEASE_PATH=~/cf-release/ ./generate_deployment_manifest.sh $TARGET_PLATFORM > ~/cf-manifest.yml
-}
-
-cf_deploy() {
-  $BOSH_CLI deployment ~/cf-manifest.yml
-  time $BOSH_CLI -n deploy
-}
-
-cf_post_deploy() {
-  # Deploy psql broker
-  time bash $SCRIPT_DIR/deploy_psql_broker.sh \
-    admin $(get_cf_secret secrets/uaa_admin_password) \
-    admin $(get_cf_secret secrets/postgres_password)
-}
-
 install_dependencies
 deploy_and_login_bosh
 cf_prepare_deployment
-cf_compile_manifest
-cf_deploy
-cf_post_deploy


### PR DESCRIPTION
## What

We want to save time when recreating Cloud Foundry environments. This PR allows to delete CF and any other deployments but keep BOSH running with all its releases, stemcells and compiled packages.

We will then be able to:
- Delete deployments at night to save costs
- Recreate environments quickly for each story
## How to review
- Create a complete new CF environment _or_ run `make prepare-provision` to update the scripts
- Delete deployments:
  
  ```
  make delete-deployments-gce DEPLOY_ENV=<environment_name> # or...
  make delete-deployments-aws DEPLOY_ENV=<environment_name>
  ```
- Recreate the CF environment with `make aws|gce`, it should last less than 10 minutes
## Who can review

Anyone but @saliceti or @keymon 
