### PR TITLE
 #105015670 Pass new cf admin credentials to the smoke test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ test-gce: set-gce test
 test: bastion
 	$(eval domain=$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate dns_zone_name))
 	smoke_test/smoke_test.json.sh \
-	    ${DEPLOY_ENV} ${domain} > \
+	    ${DEPLOY_ENV} ${domain} \
+	    admin `PASSWORD_STORE_DIR=~/.paas-pass pass cloudfoundry/cf_admin_password` > \
 		smoke_test/smoke_test.json
 	@scp -oStrictHostKeyChecking=no \
 	    smoke_test/smoke_test.sh smoke_test/smoke_test.json \


### PR DESCRIPTION
Related: [#105015670 Cloudfoundry Smoke tests fail due to changed password](https://www.pivotaltracker.com/story/show/105015670)
# What

The password for the admin user has been changed to a secure password
stored in our password store. We need to pass the new credentials
from `paas-pass` for the admin user to be able to run the smoke tests.
## Dependencies

This depends on the right credentials stored in: `paas-pass cloudfoundry/cf_admin_password`, so [this PR must be merged first](https://github.gds/multicloudpaas/credentials/pull/13)
## how to test

With a running CF deployment with the new passwords added in #33, just run `make test-aws DEPLOY_ENV=...` or  `make test-gce DEPLOY_ENV=...`
## who can review it

Anyone but @keymon
