### PR TITLE
[#104107182] cf metrics

### DIFF
--- a/manifests/templates/aws/stubs/cf-stub-aws.yml
+++ b/manifests/templates/aws/stubs/cf-stub-aws.yml
@@ -47,6 +47,9 @@ properties:
   graphite:
     server: 10.0.10.40
   domain: (( terraform_outputs.environment ".cf.paas.alphagov.co.uk" ))
+  collector:
+    graphite:
+      address: 10.0.10.40
   cc:
     droplets:
       droplet_directory_key: (( terraform_outputs.environment "-cf-droplets" ))

--- a/manifests/templates/aws/stubs/cf-stub-aws.yml
+++ b/manifests/templates/aws/stubs/cf-stub-aws.yml
@@ -1,5 +1,5 @@
 ---
-terraform_outputs: ((merge))
+terraform_outputs: (( merge ))
 name: (( "cloudfoundry-" meta.environment ))
 meta:
   environment: (( terraform_outputs.environment ))
@@ -44,6 +44,8 @@ resource_pools:
       - (( terraform_outputs.elb_name ))
 
 properties:
+  graphite:
+    server: 10.0.10.40
   domain: (( terraform_outputs.environment ".cf.paas.alphagov.co.uk" ))
   cc:
     droplets:

--- a/manifests/templates/aws/stubs/graphite-stub.yml
+++ b/manifests/templates/aws/stubs/graphite-stub.yml
@@ -1,0 +1,7 @@
+jobs:
+  - name: graphite
+    instances: 1
+    persistent_disk: 20480
+    networks:
+    - name: cf1
+      static_ips: [ 10.0.10.40 ]

--- a/manifests/templates/deployments/cf-jobs.yml
+++ b/manifests/templates/deployments/cf-jobs.yml
@@ -1,0 +1,12 @@
+jobs:
+  - <<: (( merge ))
+  - name: consul_z1
+    <<: (( merge ))
+    update:
+      max_in_flight: 1
+      serial: false
+  - name: consul_z2
+    <<: (( merge ))
+    update:
+      max_in_flight: 1
+      serial: false

--- a/manifests/templates/deployments/collectd.yml
+++ b/manifests/templates/deployments/collectd.yml
@@ -1,0 +1,165 @@
+collectd:
+  name: collectd
+  release: collectd
+
+jobs:
+  - <<: (( merge ))
+  - name: consul_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: ha_proxy_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: nats_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: etcd_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: stats_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: nfs_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: postgres_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: uaa_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: api_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: api_worker_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: hm9000_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: runner_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: loggregator_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: doppler_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: loggregator_trafficcontroller_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: router_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+    properties:
+      <<: (( merge ))
+      router:
+        status:
+          user: router_user
+          password: router_password 
+
+  - name: consul_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: nats_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: etcd_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: uaa_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: api_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: api_worker_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: hm9000_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: runner_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: loggregator_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: doppler_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: loggregator_trafficcontroller_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: router_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+    properties:
+      <<: (( merge ))
+      router:
+        status:
+          user: router_user
+          password: router_password      
+
+properties:
+  <<: (( merge ))
+  graphite:
+    server: changeme
+    prefix: "servers."

--- a/manifests/templates/deployments/collectd.yml
+++ b/manifests/templates/deployments/collectd.yml
@@ -158,6 +158,33 @@ jobs:
           user: router_user
           password: router_password      
 
+  # Can't deploy to graphite due to package name conflict ('python')
+  - name: postgres
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: elasticsearch_master_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: elasticsearch_master_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: elasticsearch_data_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: elasticsearch_data_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+
 properties:
   <<: (( merge ))
   graphite:

--- a/manifests/templates/deployments/collectd.yml
+++ b/manifests/templates/deployments/collectd.yml
@@ -9,6 +9,11 @@ jobs:
     templates:
       - <<: (( merge ))
       - (( collectd ))
+  - name: consul_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
   - name: ha_proxy_z1
     <<: (( merge ))
     templates:
@@ -19,7 +24,17 @@ jobs:
     templates:
       - <<: (( merge ))
       - (( collectd ))
+  - name: nats_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
   - name: etcd_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: etcd_z2
     <<: (( merge ))
     templates:
       - <<: (( merge ))
@@ -44,7 +59,22 @@ jobs:
     templates:
       - <<: (( merge ))
       - (( collectd ))
+  - name: uaa_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
   - name: api_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: api_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: clock_global
     <<: (( merge ))
     templates:
       - <<: (( merge ))
@@ -54,7 +84,17 @@ jobs:
     templates:
       - <<: (( merge ))
       - (( collectd ))
+  - name: api_worker_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
   - name: hm9000_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: hm9000_z2
     <<: (( merge ))
     templates:
       - <<: (( merge ))
@@ -64,7 +104,17 @@ jobs:
     templates:
       - <<: (( merge ))
       - (( collectd ))
+  - name: runner_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
   - name: loggregator_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: loggregator_z2
     <<: (( merge ))
     templates:
       - <<: (( merge ))
@@ -74,7 +124,17 @@ jobs:
     templates:
       - <<: (( merge ))
       - (( collectd ))
+  - name: doppler_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
   - name: loggregator_trafficcontroller_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( collectd ))
+  - name: loggregator_trafficcontroller_z2
     <<: (( merge ))
     templates:
       - <<: (( merge ))
@@ -89,63 +149,7 @@ jobs:
       router:
         status:
           user: router_user
-          password: router_password 
-
-  - name: consul_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: nats_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: etcd_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: uaa_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: api_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: api_worker_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: hm9000_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: runner_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: loggregator_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: doppler_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
-  - name: loggregator_trafficcontroller_z2
-    <<: (( merge ))
-    templates:
-      - <<: (( merge ))
-      - (( collectd ))
+          password: router_password
   - name: router_z2
     <<: (( merge ))
     templates:
@@ -156,7 +160,13 @@ jobs:
       router:
         status:
           user: router_user
-          password: router_password      
+          password: router_password
+
+  # Two below are defined here just to preserve job ordering
+  - name: acceptance_tests
+    <<: (( merge ))
+  - name: smoke_tests
+    <<: (( merge ))
 
   # Can't deploy to graphite due to package name conflict ('python')
   - name: postgres

--- a/manifests/templates/deployments/collector.yml
+++ b/manifests/templates/deployments/collector.yml
@@ -1,0 +1,13 @@
+name: (( merge ))
+
+jobs:
+  - <<: (( merge ))
+
+properties:
+  <<: (( merge ))
+  collector:
+    deployment_name: (( name ))
+    use_graphite: true
+    graphite:
+      address: changeme
+      port: 2003

--- a/manifests/templates/deployments/elasticsearch.yml
+++ b/manifests/templates/deployments/elasticsearch.yml
@@ -2,6 +2,12 @@ meta:
   release:
     name: cf
 
+  elasticsearch_templates:
+  - name: elasticsearch
+    release: elasticsearch
+  - name: metron_agent
+    release: (( meta.release.name ))
+
 jobs:
 - <<: (( merge ))
 - name: elasticsearch_master_z1
@@ -26,11 +32,7 @@ jobs:
       discovery_minimum_master: (( merge || 2 ))
       discovery_ping_timeout: (( merge || 3 ))
   resource_pool: (( merge || "small_z1" ))
-  templates:
-  - name: elasticsearch
-    release: elasticsearch
-  - name: metron_agent
-    release: (( meta.release.name ))
+  templates: (( merge || meta.elasticsearch_templates ))
 
 - name: elasticsearch_master_z2
   instances: 1
@@ -54,11 +56,7 @@ jobs:
       discovery_minimum_master: (( merge || 2 ))
       discovery_ping_timeout: (( merge || 3 ))
   resource_pool: (( merge || "small_z2" ))
-  templates:
-  - name: elasticsearch
-    release: elasticsearch
-  - name: metron_agent
-    release: (( meta.release.name ))
+  templates: (( merge || meta.elasticsearch_templates ))
 
 - name: elasticsearch_data_z1
   instances: 2
@@ -82,11 +80,7 @@ jobs:
       discovery_minimum_master: (( merge || 2 ))
       discovery_ping_timeout: (( merge || 3 ))
   resource_pool: (( merge || "medium_z1" ))
-  templates:
-  - name: elasticsearch
-    release: elasticsearch
-  - name: metron_agent
-    release: (( meta.release.name ))
+  templates: (( merge || meta.elasticsearch_templates ))
 
 - name: elasticsearch_data_z2
   instances: 2
@@ -110,10 +104,4 @@ jobs:
       discovery_minimum_master: (( merge || 2 ))
       discovery_ping_timeout: (( merge || 3 ))
   resource_pool: (( merge || "medium_z1" ))
-  templates:
-  - name: elasticsearch
-    release: elasticsearch
-  - name: metron_agent
-    release: (( meta.release.name ))
-
-
+  templates: (( merge || meta.elasticsearch_templates ))

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -1,0 +1,49 @@
+meta:
+  release:
+    name: cf
+
+jobs:
+- <<: (( merge ))
+- name: graphite
+  instances: 1
+  resource_pool: (( merge || "small_z1" ))
+  default_networks:
+  - name: cf1
+    static_ips: ~
+  networks: (( merge || default_networks ))
+  persistent_disk: (( merge || 2048 ))
+  properties:
+    metron_agent:
+      zone: z1
+    carbon:
+      storage_schemas:
+        - name: "my_storage_schema"
+          pattern: "^my\\.metrics\\.*" # NB: Note the double escapes - this will evaluate to "^my\.metrics\.*"
+          retentions: "60s:1d"
+        - name: "my_storage_schema_2"
+          pattern: "metrics$"
+          retentions: "15s:7d,1m:21d,15m:5y"
+      storage_aggregations:
+        - name: "my_storage_aggregation"
+          pattern: "^my\\.metrics\\.*" # NB: Note the double escapes - this will evaluate to "^my\.metrics\.*"
+          xFilesFactor: "0.5"
+          aggregationMethod: "average"
+        - name: "my_storage_aggregation_2"
+          pattern: "metrics$"
+          xFilesFactor: "0.1"
+          aggregationMethod: "max"
+    graphite-web:
+      time_zone: Europe/London
+      httpd:
+        port: 80
+      wsgi:
+        inactivity-timeout: 60
+  templates:
+  - name: carbon
+    release: graphite
+  - name: graphite-web
+    release: graphite
+  - name: statsd
+    release: graphite
+  - name: metron_agent
+    release: (( meta.release.name ))

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -38,6 +38,11 @@ jobs:
         port: 80
       wsgi:
         inactivity-timeout: 60
+    grafana:
+      root_url: "/"
+      admin_username: "admin"
+      admin_password: "admin"
+
   templates:
   - name: carbon
     release: graphite
@@ -47,3 +52,5 @@ jobs:
     release: graphite
   - name: metron_agent
     release: (( meta.release.name ))
+  - name: grafana
+    release: grafana

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -2,6 +2,18 @@ meta:
   release:
     name: cf
 
+  graphite_templates:
+    - name: carbon
+      release: graphite
+    - name: graphite-web
+      release: graphite
+    - name: statsd
+      release: graphite
+    - name: metron_agent
+      release: (( meta.release.name ))
+    - name: grafana
+      release: grafana
+
 jobs:
 - <<: (( merge ))
 - name: graphite
@@ -43,14 +55,4 @@ jobs:
       admin_username: "admin"
       admin_password: "admin"
 
-  templates:
-  - name: carbon
-    release: graphite
-  - name: graphite-web
-    release: graphite
-  - name: statsd
-    release: graphite
-  - name: metron_agent
-    release: (( meta.release.name ))
-  - name: grafana
-    release: grafana
+  templates: (( merge || meta.graphite_templates ))

--- a/manifests/templates/deployments/postgres.yml
+++ b/manifests/templates/deployments/postgres.yml
@@ -1,3 +1,10 @@
+meta:
+  postgres_templates:
+    - name: postgres
+      release: cf
+    - name: metron_agent
+      release: cf
+
 secrets: (( merge ))
 jobs:
 - <<: (( merge ))
@@ -31,8 +38,4 @@ jobs:
         - tag: psqlbroker
           name: psqlbroker
   resource_pool: (( merge || "medium_z1" ))
-  templates:
-    - name: postgres
-      release: cf
-    - name: metron_agent
-      release: cf
+  templates: (( merge || meta.postgres_templates ))

--- a/manifests/templates/gce/cf-infrastructure-gce.yml
+++ b/manifests/templates/gce/cf-infrastructure-gce.yml
@@ -75,14 +75,14 @@ resource_pools:
   - name: small_z1
     cloud_properties:
       machine_type: f1-micro
-      root_disk_size_gb: 4
+      root_disk_size_gb: 10
       root_disk_type: pd-standard
       zone: (( meta.zones.z1 ))
 
   - name: small_z2
     cloud_properties:
       machine_type: f1-micro
-      root_disk_size_gb: 4
+      root_disk_size_gb: 10
       root_disk_type: pd-standard
       zone: (( meta.zones.z2 ))
 
@@ -131,14 +131,14 @@ resource_pools:
   - name: router_z1
     cloud_properties:
       machine_type: g1-small
-      root_disk_size_gb: 4
+      root_disk_size_gb: 10
       root_disk_type: pd-standard
       zone: (( meta.zones.z1 ))
 
   - name: router_z2
     cloud_properties:
       machine_type: g1-small
-      root_disk_size_gb: 4
+      root_disk_size_gb: 10
       root_disk_type: pd-standard
       zone: (( meta.zones.z2 ))
 

--- a/manifests/templates/gce/cf-infrastructure-gce.yml
+++ b/manifests/templates/gce/cf-infrastructure-gce.yml
@@ -60,7 +60,7 @@ properties:
       fog_connection: (( meta.fog_config ))
 
   uaa:
-    catalina_opts: -Xmx768m -XX:MaxPermSize=256m
+    catalina_opts: -Xmx512m -XX:MaxPermSize=256m
 
   nats:
     address: (( merge || meta.nats.address ))

--- a/manifests/templates/gce/cf-infrastructure-gce.yml
+++ b/manifests/templates/gce/cf-infrastructure-gce.yml
@@ -1,4 +1,4 @@
-name: ((merge))
+name: (( merge ))
 meta:
   zones:
     z1: (( properties.template_only.gce.availability_zone ))

--- a/manifests/templates/gce/stubs/cf-stub-gce.yml
+++ b/manifests/templates/gce/stubs/cf-stub-gce.yml
@@ -60,6 +60,9 @@ properties:
   graphite:
     server: (( "0.graphite.cf1." .name ".microbosh" ))
   domain: (( terraform_outputs.environment ".cf2.paas.alphagov.co.uk" ))
+  collector:
+    graphite:
+      address: (( "0.graphite.cf1." .name ".microbosh" ))
   template_only:
     gce:
       availability_zone: (( terraform_outputs.zone0 ))

--- a/manifests/templates/gce/stubs/cf-stub-gce.yml
+++ b/manifests/templates/gce/stubs/cf-stub-gce.yml
@@ -1,5 +1,5 @@
 ---
-terraform_outputs: ((merge))
+terraform_outputs: (( merge ))
 secrets: (( merge ))
 name: (( "cloudfoundry-" meta.environment ))
 meta:
@@ -57,6 +57,8 @@ networks:
       target_pool: (( terraform_outputs.router_pool_name ))
 
 properties:
+  graphite:
+    server: (( "0.graphite.cf1." .name ".microbosh" ))
   domain: (( terraform_outputs.environment ".cf2.paas.alphagov.co.uk" ))
   template_only:
     gce:

--- a/manifests/templates/gce/stubs/graphite-stub.yml
+++ b/manifests/templates/gce/stubs/graphite-stub.yml
@@ -1,0 +1,7 @@
+jobs:
+  - name: graphite
+    instances: 1
+    persistent_disk: 20480
+    networks:
+    - name: cf1
+      static_ips: null

--- a/manifests/templates/stubs/cf-stub.yml
+++ b/manifests/templates/stubs/cf-stub.yml
@@ -19,6 +19,8 @@ jobs:
     instances: 1
   - name: consul_z1
     instances: 1
+  - name: stats_z1
+    instances: 1
 
 properties:
   cc:

--- a/manifests/templates/stubs/cf-stub.yml
+++ b/manifests/templates/stubs/cf-stub.yml
@@ -20,7 +20,6 @@ jobs:
   - name: consul_z1
     instances: 1
 
-
 properties:
   cc:
     staging_upload_user: username

--- a/manifests/templates/stubs/cf-stub.yml
+++ b/manifests/templates/stubs/cf-stub.yml
@@ -54,6 +54,13 @@ properties:
     clients:
       app-direct:
         secret: (( secrets.uaa_clients_app_direct_secret ))
+      graphite-nozzle:
+        access-token-validity: 1209600
+        authorized-grant-types: authorization_code,client_credentials,refresh_token
+        override: true
+        secret: (( secrets.uaa_clients_firehose_password ))
+        scope: openid,oauth.approvals,doppler.firehose
+        authorities: oauth.login,doppler.firehose
       developer_console:
         secret: (( secrets.uaa_clients_developer_console_secret ))
       login:

--- a/manifests/templates/stubs/releases.yml
+++ b/manifests/templates/stubs/releases.yml
@@ -5,3 +5,5 @@ releases:
   version: 0.1.0
 - name: graphite
   version: latest
+- name: grafana
+  version: latest

--- a/manifests/templates/stubs/releases.yml
+++ b/manifests/templates/stubs/releases.yml
@@ -7,3 +7,5 @@ releases:
   version: latest
 - name: grafana
   version: latest
+- name: collectd
+  version: latest

--- a/manifests/templates/stubs/releases.yml
+++ b/manifests/templates/stubs/releases.yml
@@ -3,4 +3,5 @@ releases:
   version: 215
 - name: elasticsearch
   version: 0.1.0
-
+- name: graphite
+  version: latest

--- a/scripts/deploy_cf.sh
+++ b/scripts/deploy_cf.sh
@@ -53,6 +53,10 @@ cf_post_deploy() {
   time bash $SCRIPT_DIR/deploy_psql_broker.sh \
     admin $(get_cf_secret secrets/uaa_admin_password) \
     admin $(get_cf_secret secrets/postgres_password)
+  # Deploy graphite nozzle
+  time bash $SCRIPT_DIR/deploy_graphite_nozzle.sh \
+    admin $(get_cf_secret secrets/uaa_admin_password) \
+    graphite-nozzle $(get_cf_secret secrets/uaa_clients_firehose_password)
 }
 
 cf_compile_manifest

--- a/scripts/deploy_graphite_nozzle.sh
+++ b/scripts/deploy_graphite_nozzle.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+echo "*** Deploying and starting graphite nozzle..."
+
+CF_ADMIN="$1"
+CF_PASS="$2"
+FIREHOSE_USER="$3"
+FIREHOSE_PASS="$4"
+
+DOMAIN=`python -c 'import yaml; print yaml.load(file("cf-manifest.yml"))["properties"]["domain"]'`
+DOPPLER_SERVER=`bosh vms | grep doppler_z1/0 | grep -o '10\.[0-9]\+\.[0-9]\+\.[0-9]\+'`
+GRAPHITE_SERVER=`bosh vms | grep graphite/0 | grep -o '10\.[0-9]\+\.[0-9]\+\.[0-9]\+'`
+
+echo "*** Logging in to CF and creating admin space..."
+cf api --skip-ssl-validation https://api.${DOMAIN}
+echo | cf login -u ${CF_ADMIN} -p ${CF_PASS}
+echo | cf create-org admin
+cf create-space admin -o admin
+cf target -o admin -s admin
+
+git clone https://github.com/CloudCredo/graphite-nozzle go/src/github.com/cloudcredo/graphite-nozzle
+cd go/src/github.com/cloudcredo/graphite-nozzle
+
+# The buildpack only supports go1.4.0-2
+cat <<EOF | python
+import json
+j = json.load(open('Godeps/Godeps.json'));
+j['GoVersion'] = 'go1.4.2';
+f = open('Godeps/Godeps.json','w');
+f.write(json.dumps(j, indent=4));
+f.close()
+EOF
+
+# The sleep 1 is to avoid logs being eaten if the configuration is wrong
+# due to this bug: https://github.com/cloudfoundry/loggregator/issues/86
+echo "web: sleep 1 && graphite-nozzle" > Procfile
+
+cat <<EOF > manifest.yml
+---
+applications:
+- name: graphite-nozzle
+  memory: 100M
+  instances: 1
+  no-route: true
+EOF
+
+cf push --no-start
+
+cf set-env graphite-nozzle DOPPLER_ENDPOINT "ws://${DOPPLER_SERVER}:8081"
+cf set-env graphite-nozzle UAA_ENDPOINT "https://uaa.${DOMAIN}"
+cf set-env graphite-nozzle STATSD_ENDPOINT "${GRAPHITE_SERVER}:8125"
+cf set-env graphite-nozzle FIREHOSE_USERNAME "${FIREHOSE_USER}"
+cf set-env graphite-nozzle FIREHOSE_PASSWORD "${FIREHOSE_PASS}"
+cf set-env graphite-nozzle SUBSCRIPTION_ID firehose
+cf set-env graphite-nozzle STATSD_PREFIX cfstats.
+cf set-env graphite-nozzle SKIP_SSL_VALIDATION true
+
+cat <<EOF > graphite-nozzle.json
+[
+    {"protocol":"tcp","destination":"${DOPPLER_SERVER}","ports":"8081"},
+    {"protocol":"udp","destination":"${GRAPHITE_SERVER}","ports":"8125"}
+]
+EOF
+cf create-security-group graphite-nozzle graphite-nozzle.json
+cf bind-staging-security-group graphite-nozzle
+cf bind-running-security-group graphite-nozzle
+
+cf start graphite-nozzle

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -169,21 +169,10 @@ git_clone() {
   git checkout -q ${revision}
 }
 
-clone_and_update_cf_release(){
+clone_and_update_cf_release() {
   # Git clone and upload release
   echo "Updating ~/cf-release from $CF_RELEASE_GIT_URL:$CF_RELEASE_REVISION"
-
-  if [ ! -d ~/cf-release/.git ]; then
-    rm -rf ~/cf-release
-    git clone -q $CF_RELEASE_GIT_URL ~/cf-release
-  else
-    cd ~/cf-release
-    git remote set-url origin $CF_RELEASE_GIT_URL
-    git fetch -q
-  fi
-
-  cd ~/cf-release
-  git checkout -q $CF_RELEASE_REVISION
+  git_clone $CF_RELEASE_GIT_URL $CF_RELEASE_REVISION
 
   ./update  >> update.log 2>&1
   if [ $? != 0 ]; then

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -60,7 +60,7 @@ BOSH_CLI="bundle exec bosh"
 export PATH=$PATH:/usr/local/bin
 
 # Preinstallation of packages
-function install_dependencies {
+install_dependencies() {
   PACKAGES="
     build-essential
     git
@@ -149,6 +149,24 @@ deploy_and_login_bosh() {
     return 1
   fi
 
+}
+
+git_clone() {
+  local url=$1
+  local revision=$2
+  path=$(echo ${url} | sed "s|.*/||;s|.git||")
+
+  if [ ! -d ~/${path}/.git ]; then
+    rm -rf ~/${path}
+    git clone -q ${url} ~/${path}
+  else
+    cd ~/${path}
+    git remote set-url origin ${url}
+    git fetch -q
+  fi
+
+  cd ~/${path}
+  git checkout -q ${revision}
 }
 
 clone_and_update_cf_release(){

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -44,6 +44,7 @@ elasticsearch,0.1.0,https://github.com/hybris/elasticsearch-boshrelease/releases
 
 # Dependencies versions
 GRAPHITE_VERSION="0d79bf5aa5f2cf29195bff725d7dee55dea1aedc"
+GRAFANA_VERSION="44564533c9d4d656bdcd5633b808f0bf6fb177ae"
 BOSH_INIT_VERSION=0.0.72
 BOSH_INIT_URL=https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-${BOSH_INIT_VERSION}-linux-amd64
 SPIFF_VERSION=v1.0.7
@@ -188,6 +189,24 @@ cf_graphite_release() {
   fi
 }
 
+cf_grafana_release() {
+  echo "*** Creating and uploading grafana release..."
+
+  if bundle exec $SCRIPT_DIR/bosh_list_releases.rb | grep -q "grafana/${GRAFANA_VERSION}"; then
+    echo "Release grafana version ${GRAFANA_VERSION} already uploaded, skipping"
+  else
+    git_clone https://github.com/vito/grafana-boshrelease.git ${GRAFANA_VERSION}
+
+    cd ~/grafana-boshrelease
+    $BOSH_CLI create release --name grafana --version ${GRAFANA_VERSION}
+
+    $BOSH_CLI upload release 2>&1 | tee /tmp/upload_release.log
+    if [ $PIPESTATUS != 0 ] && ! grep -q -e 'Release.*already exists' /tmp/upload_release.log;  then
+      return 1
+    fi
+  fi
+}
+
 clone_and_update_cf_release() {
   # Git clone and upload release
   echo "Updating ~/cf-release from $CF_RELEASE_GIT_URL:$CF_RELEASE_REVISION"
@@ -252,4 +271,5 @@ cf_prepare_deployment() {
 install_dependencies
 deploy_and_login_bosh
 cf_graphite_release
+cf_grafana_release
 cf_prepare_deployment

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -34,7 +34,7 @@ BOSH_PORT=${BOSH_PORT:-25555}
 # Git cf-release to clone
 CF_RELEASE=215
 CF_RELEASE_GIT_URL=https://github.com/alphagov/cf-release.git
-CF_RELEASE_REVISION='cf_jobs_without_static_ips_dependencies_v215_103419194_with_dea_next_mtu'
+CF_RELEASE_REVISION=gds-paas
 
 # Releases to upload
 BOSH_RELEASES="


### PR DESCRIPTION
## What

We want to gather metrics about the cloudfoundry components in order to evaluate how the platform performs during subsequent performance testing stories. This adds graphite (+grafana) as a metrics logging and viewing endpoint, graphite-nozzle as a method of logging the CF internal metrics, and collectd to log system level metrics. We also use collectd to get stats from legacy `/varz` and `/healthz` component endpoints.
## Scope

We need to both hook into existing CF monitoring pipelines, deploy new monitoring agents across the cluster, and provide endpoints for both collecting the metrics and viewing them. We are not exposing the viewing endpoints to the outside world in this story, or monitoring deployed application performance.
## How to test it
- Deploy a new CF cluster. You can use either AWS or GCE, it doesn't matter.
- `bosh vms` on the bastion, grab the graphite IP address.
### Testing Graphite web interface
- Create an SSH tunnel to the graphite web interface `ssh ubuntu@bastionhost -L 8080:graphiteipaddress:80`.
- Open a browser to http://localhost:8080. Browsing the stats dropdowns on the left should reveal per-host system metrics from collectd, and cf system metrics under statsd.
### Testing Grafana web interface
- If you want to test grafana, create an SSH tunnel `ssh ubuntu@bastionhost -L 3000:graphiteipaddress:3000`.
- Open a browser to http://localhost:8080, login is admin/admin.
- Add a new graphite data source for "http://127.0.0.1:80".
- You should now be able to create a new dashboard and add metrics to it from the graphite server.
## Who can review this

Anyone but @mtekel or @jonty.
