### PR TITLE
[#104107182] Revert custom router status PW

### DIFF
--- a/manifests/templates/deployments/collectd.yml
+++ b/manifests/templates/deployments/collectd.yml
@@ -144,23 +144,11 @@ jobs:
     templates:
       - <<: (( merge ))
       - (( collectd ))
-    properties:
-      <<: (( merge ))
-      router:
-        status:
-          user: router_user
-          password: router_password
   - name: router_z2
     <<: (( merge ))
     templates:
       - <<: (( merge ))
       - (( collectd ))
-    properties:
-      <<: (( merge ))
-      router:
-        status:
-          user: router_user
-          password: router_password
 
   # Two below are defined here just to preserve job ordering
   - name: acceptance_tests

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -38,7 +38,7 @@ CF_RELEASE_REVISION=gds-paas
 
 # Releases to upload
 BOSH_RELEASES="
-cf,215,https://bosh.io/d/github.com/cloudfoundry/cf-release?v=$CF_RELEASE
+cf,$CF_RELEASE,https://bosh.io/d/github.com/cloudfoundry/cf-release?v=$CF_RELEASE
 elasticsearch,0.1.0,https://github.com/hybris/elasticsearch-boshrelease/releases/download/v0.1.0/elasticsearch-0.1.0.tgz
 graphite,0d79bf5aa5f2cf29195bff725d7dee55dea1aedc,https://github.com/CloudCredo/graphite-statsd-boshrelease.git,create
 collectd,ec9de5dc63715237688c3b27154c86a0c22b3aef,https://github.com/alphagov/collectd-graphite-boshrelease.git,create


### PR DESCRIPTION
Don't override router status user name and password in router properties.
This was initially described as a way to let collectd know about the varz
router endpoint user and password, but in reality it also overrides/sets
these. Use global values specified in properties instead.
