### PR TITLE
[#103903920] Changes for CI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ gce: set-gce apply prepare-provision-gce provision deploy-cf
 apply-aws: set-aws apply
 apply-gce: set-gce apply
 apply: check-env-vars
-	@cd ${dir} && terraform get && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} ${apply_suffix}
+	@cd ${dir} && terraform get && terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} ${apply_suffix} \
+		|| terraform apply -state=${DEPLOY_ENV}.tfstate -var env=${DEPLOY_ENV} ${apply_suffix}
 
 manifests/templates/outputs/terraform-outputs-aws.yml: aws/${DEPLOY_ENV}.tfstate
 	./scripts/extract_terraform_outputs_to_yml.rb < aws/${DEPLOY_ENV}.tfstate > manifests/templates/outputs/terraform-outputs-aws.yml


### PR DESCRIPTION
# What
- Allows to use different sets of passwords, stored in separate directories inside `paas-pass`
- Retries the terraform command in case of failure because it frequently fails
# How to review

This should be reviewed along main PR from story 103903920 in https://github.com/alphagov/multicloud-deploy
- To test specifically the passwords change:

```
make aws DEPLOY_ENV=abcd ROOT_PASS_DIR=jenkins
```
- To test specifically the retry, build a terraform environment. It should retry automatically in case of error:

```
make apply-aws DEPLOY_ENV=abcd
```
# Who can review

Aynone but @saliceti, @jimconner, @Jonty 
