### PR TITLE
Increase the ELB idle timeout to 300 seconds.

### DIFF
--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -1,6 +1,7 @@
 resource "aws_elb" "router" {
   name = "${var.env}-cf-router-elb"
   subnets = ["${aws_subnet.infra.*.id}"]
+  idle_timeout = "${var.elb_idle_timeout}"
   security_groups = [
     "${aws_security_group.web.id}",
   ]

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -68,6 +68,11 @@ variable "health_check_unhealthy" {
   default     = 2
 }
 
+variable "elb_idle_timeout" {
+  description = "Timeout idle connections after 300 seconds"
+  default     = 300
+}
+
 variable "dns_zone_id" {
   description = "Amazon Route53 DNS zone identifier"
   default = "Z3SI0PSH6KKVH4"


### PR DESCRIPTION
[Postgres-cf-service-broker fails to start](https://www.pivotaltracker.com/n/projects/1275640/stories/105214754)

**What**
The AWS elstic load balancer will timeout connections after a number
of seconds of inactivity. By default this is set to 60 seconds, but this
was causing problems with the deployment of the postgresql-service-broker
when pushing the app to a freshly deployed CF.

After investigation, it was found that there is a long period of inactivity
between the CF CLI client and the API server whilst the DEA downloaded and
unpacked the buildpacks required by the psql broker. It appears that we need
to allow at least 157 seconds for these buildpack steps to complete the first
time.

Increasing the AWS ELB idle_timeout up to 300 seconds allows for all of the
buildpack steps to complete, and allows the psql broker to deploy without
error.

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I want deployment to AWS to succeed without hitting the error:

`Error performing request: Put https://api.psqlbug.cf.paas.alphagov.co.uk/v2/apps/62f02443-75b5-4d2d-8df4-d0a23d5f38cd?async=true&inline-relations-depth=1: http: Request.ContentLength=19 with Body length 0`

**How to test this PR**

Deploy to AWS as normal using a `make aws DEPLOY_ENV=<some_evironment_name>`

**Who should review this PR**

Anyone on the core team except for @jimconner

**Notes**

This fix has been tested only one time before raising this PR - Ideally I'd like to test it again with a full deployment, but as we're all hitting this bug at the moment, I'm doing a PR early so that we can all test.
