### PR TITLE
[#100205808] AWS: Enable cross zone load balancing

### DIFF
--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -2,6 +2,7 @@ resource "aws_elb" "router" {
   name = "${var.env}-cf-router-elb"
   subnets = ["${aws_subnet.infra.*.id}"]
   idle_timeout = "${var.elb_idle_timeout}"
+  cross_zone_load_balancing = "true"
   security_groups = [
     "${aws_security_group.web.id}",
   ]


### PR DESCRIPTION
Without cross zone load balancing, if a router (or all routers) in one
zone go down, then ELB in that zone will not forward requests further,
but return 502/4 or drop them. With cross zone LB enabled, it would
forward to other zone, not impacting service availability. Cross zone
LB also equalizes load on each zone, in case if for some reason (
usually DNS related) ELB in one zone gets many more request than ELB in
other zone...
