### PR TITLE
[#100205808] Remove API Worker

### DIFF
--- a/manifests/templates/deployments/api.yml
+++ b/manifests/templates/deployments/api.yml
@@ -1,0 +1,16 @@
+worker:
+  name: cloud_controller_worker
+  release: cf
+
+jobs:
+  - name: api_z1
+    <<: (( merge ))
+    templates:
+      - (( worker ))
+      - <<: (( merge ))
+  - name: api_z2
+    <<: (( merge ))
+    templates:
+      - (( worker ))
+      - <<: (( merge ))
+  - <<: (( merge ))

--- a/manifests/templates/deployments/api.yml
+++ b/manifests/templates/deployments/api.yml
@@ -3,6 +3,10 @@ worker:
   release: cf
 
 jobs:
+  - name: consul_z1
+    <<: (( merge ))
+  - name: consul_z2
+    <<: (( merge ))
   - name: api_z1
     <<: (( merge ))
     templates:

--- a/manifests/templates/stubs/cf-stub.yml
+++ b/manifests/templates/stubs/cf-stub.yml
@@ -13,6 +13,8 @@ update:
   serial: false # makes every job deploy at the same time.
 
 jobs:
+  - name: api_worker_z1
+    instances: 0
   - name: runner_z1
     instances: 1
   - name: runner_z2


### PR DESCRIPTION
Api Worker only does asynchronous jobs. Other jobs are done by the API
server itself. In this commit we remove API Worker server and add the
worker template to the API server. This way API server will be able to
do all kinds of jobs. To scale, we now just need to add more API servers
instead of managing 2 separate pools of instances, which both need some
minimal amount of instances for resiliency...
