### PR TITLE
[#103003432] Secure access to cloudfoundry routers on AWS and GCE

### DIFF
--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -152,21 +152,39 @@ resource "aws_security_group" "web" {
     from_port = 80
     to_port   = 80
     protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [
+      "${split(",", var.office_cidrs)}",
+      "${aws_instance.bastion.public_ip}/32"
+    ]
+    security_groups = [
+      "${aws_security_group.bosh_vm.id}"
+    ]
   }
 
   ingress {
     from_port = 443
     to_port   = 443
     protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [
+      "${split(",", var.office_cidrs)}",
+      "${aws_instance.bastion.public_ip}/32"
+    ]
+    security_groups = [
+      "${aws_security_group.bosh_vm.id}"
+    ]
   }
 
   ingress {
     from_port = 4443
     to_port   = 4443
     protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [
+      "${split(",", var.office_cidrs)}",
+      "${aws_instance.bastion.public_ip}/32"
+    ]
+    security_groups = [
+      "${aws_security_group.bosh_vm.id}"
+    ]
   }
 
   tags {

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "bastion" {
   name = "${var.env}-bastion"
-  description = "Security group for bastion that allows SSH traffic from the office"
+  description = "Security group for bastion that allows NAT traffic and SSH connections from the office"
   vpc_id = "${aws_vpc.default.id}"
 
   egress {
@@ -11,19 +11,19 @@ resource "aws_security_group" "bastion" {
   }
 
   ingress {
-    from_port = 22
-    to_port   = 22
-    protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}"]
-  }
-
-  ingress {
     from_port = 0
     to_port   = 0
     protocol  = "-1"
     security_groups = [
       "${aws_security_group.bosh_vm.id}"
     ]
+  }
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["${split(",", var.office_cidrs)}"]
   }
 
   tags {
@@ -53,21 +53,21 @@ resource "aws_security_group" "director" {
   }
 
   ingress {
+    from_port = 6868
+    to_port   = 6868
+    protocol  = "tcp"
+    security_groups = [
+      "${aws_security_group.bastion.id}",
+    ]
+  }
+
+  ingress {
     from_port = 4222
     to_port   = 4222
     protocol  = "tcp"
     security_groups = [
       "${aws_security_group.bastion.id}",
       "${aws_security_group.bosh_vm.id}",
-    ]
-  }
-
-  ingress {
-    from_port = 6868
-    to_port   = 6868
-    protocol  = "tcp"
-    security_groups = [
-      "${aws_security_group.bastion.id}",
     ]
   }
 

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -36,7 +36,8 @@ resource "google_compute_firewall" "internal" {
   description = "Open internal communication between instances"
   network = "${google_compute_network.bastion.name}"
 
-  source_ranges = [ "${var.bastion_cidr}", "${google_compute_address.bosh.address}/32",
+  source_ranges = [ "${var.bastion_cidr}",
+                    "${google_compute_address.bosh.address}/32",
                     "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}/32",
                     "${google_compute_instance.bastion.network_interface.0.address}/32" ]
   target_tags = [ "bosh" ]

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -57,7 +57,11 @@ resource "google_compute_firewall" "web" {
   description = "Security group for web that allows web traffic from internet"
   network = "${google_compute_network.bastion.name}"
 
-  source_ranges = [ "0.0.0.0/0" ]
+  source_ranges = [ "${split(",", var.office_cidrs)}",
+                    "${var.bastion_cidr}",
+                    "${google_compute_address.bosh.address}/32",
+                    "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}/32",
+                    "${google_compute_instance.bastion.network_interface.0.address}/32" ]
   target_tags = [ "router1", "router2" ]
 
   allow {


### PR DESCRIPTION
[#103003432 Secure access to cloudfoundry in GCE](https://www.pivotaltracker.com/story/show/103003432)
## What

During the Beta phase, we want to restrict access to the CF entry point (LB for go routers) so only the office IPs and the cloudfoundry installation itself can connect. 

This replicates the setup in tsuru.
## How to test the PR
### 1. Start the environments and apply the config changes

If you don't **have any environment running** (see below if you have), then deploy an environment on GCE and on AWS:

```
make aws DEPLOY_ENV=...
make gce DEPLOY_ENV=...
```

If you **do have an environment running**, just apply the terraform changes to update the security groups and the firewalls:

```
make apply-aws DEPLOY_ENV=...
make apply-gce DEPLOY_ENV=...
```
### 2. Check that the environment works and you are able to deploy from the office

Run the smoketests:

```
make test-aws DEPLOY_ENV=...
make test-gce DEPLOY_ENV=...
```

Deploy an app:

```
DEPLOY_ENV=myenv
git clone https://github.com/cloudfoundry-samples/spring-music.git
cd spring-music
cf login --skip-ssl-validation -a https://api.$DEPLOY_ENV.cf.paas.alphagov.co.uk  -u admin -p $(paas-pass cloudfoundry/cf_admin_password)
cf push
```

And check the app.
### 3. Check that the environment works and you are able to deploy from the office

Check connectivity, using a command like:

```
# For AWS:
nc -v -G 1 -w 1 api.$DEPLOY_ENV.cf.paas.alphagov.co.uk 80
nc -v -G 1 -w 1 api.$DEPLOY_ENV.cf.paas.alphagov.co.uk 443
# For GCE:
nc -v -G 1 -w 1 api.$DEPLOY_ENV.cf2.paas.alphagov.co.uk 80
nc -v -G 1 -w 1 api.$DEPLOY_ENV.cf2.paas.alphagov.co.uk 443
```

Test from: 
1. GDS Office: Should connect
2. Bastion host to same CF installation (e.p. AWS to AWS): Should connect
3. Any CF vm (e.g. `bosh ssh runner_z1`) to same CF installation: Should connect
4. From random internet (Example, from AWS to GCE): should timeout.
# Who can review it

Anyone but @keymon
