### PR TITLE
[#103903920] Add jenkins to firewall

### DIFF
--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -23,7 +23,7 @@ resource "aws_security_group" "bastion" {
     from_port = 22
     to_port   = 22
     protocol  = "tcp"
-    cidr_blocks = ["${split(",", var.office_cidrs)}"]
+    cidr_blocks = ["${split(",", var.office_cidrs)}", "${var.jenkins_elastic}"]
   }
 
   tags {

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "bastion" {
   name = "${var.env}-bastion"
-  description = "Security group for bastion that allows NAT traffic and SSH connections from the office"
+  description = "Security group for bastion that allows NAT traffic and SSH connections from the office and jenkins"
   vpc_id = "${aws_vpc.default.id}"
 
   egress {
@@ -138,7 +138,7 @@ resource "aws_security_group" "bosh_vm" {
 
 resource "aws_security_group" "web" {
   name = "${var.env}-web-cf"
-  description = "Security group for web that allows web traffic from internet"
+  description = "Security group for web that allows web traffic from the office and jenkins"
   vpc_id = "${aws_vpc.default.id}"
 
   egress {
@@ -154,7 +154,8 @@ resource "aws_security_group" "web" {
     protocol  = "tcp"
     cidr_blocks = [
       "${split(",", var.office_cidrs)}",
-      "${aws_instance.bastion.public_ip}/32"
+      "${aws_instance.bastion.public_ip}/32",
+      "${var.jenkins_elastic}"
     ]
     security_groups = [
       "${aws_security_group.bosh_vm.id}"
@@ -167,7 +168,8 @@ resource "aws_security_group" "web" {
     protocol  = "tcp"
     cidr_blocks = [
       "${split(",", var.office_cidrs)}",
-      "${aws_instance.bastion.public_ip}/32"
+      "${aws_instance.bastion.public_ip}/32",
+      "${var.jenkins_elastic}"
     ]
     security_groups = [
       "${aws_security_group.bosh_vm.id}"
@@ -180,7 +182,8 @@ resource "aws_security_group" "web" {
     protocol  = "tcp"
     cidr_blocks = [
       "${split(",", var.office_cidrs)}",
-      "${aws_instance.bastion.public_ip}/32"
+      "${aws_instance.bastion.public_ip}/32",
+      "${var.jenkins_elastic}"
     ]
     security_groups = [
       "${aws_security_group.bosh_vm.id}"

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -54,11 +54,12 @@ resource "google_compute_firewall" "internal" {
 
 resource "google_compute_firewall" "web" {
   name = "${var.env}-cf-web"
-  description = "Security group for web that allows web traffic from internet"
+  description = "Security group for web that allows web traffic from the office and jenkins"
   network = "${google_compute_network.bastion.name}"
 
   source_ranges = [ "${split(",", var.office_cidrs)}",
                     "${var.bastion_cidr}",
+                    "${var.jenkins_elastic}",
                     "${google_compute_address.bosh.address}/32",
                     "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}/32",
                     "${google_compute_instance.bastion.network_interface.0.address}/32" ]

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -3,7 +3,7 @@ resource "google_compute_firewall" "ssh" {
   description = "SSH from trusted external sources"
   network = "${google_compute_network.bastion.name}"
 
-  source_ranges = [ "${split(",", var.office_cidrs)}" ]
+  source_ranges = [ "${split(",", var.office_cidrs)}", "${var.jenkins_elastic}" ]
   target_tags = [ "bastion", "bosh" ]
 
   allow {

--- a/globals.tf
+++ b/globals.tf
@@ -16,3 +16,8 @@ variable "microbosh_IP" {
   description = "microbosh internal IP. Do not change. This is more of a constant than variable."
   default     = "10.0.0.6"
 }
+
+variable "jenkins_elastic" {
+  description = "Elastic IP for Jenkins server which will be trusted"
+  default     = "52.17.162.85/32"
+}


### PR DESCRIPTION
# What

Ingress rules to let jenkins connect to bastion and routers on Cloud Foundry.
# How to review
- Spin up new GCE and AWS environments
- Connect to Jenkins

```
ssh ubuntu@deploy.tools.paas.alphagov.co.uk
```
- With user `jenkins` load `insecure_deployer` key and ssh to bastion
- curl any route on router

```
$ curl abcd.colin-2.cf2.paas.alphagov.co.uk 
404 Not Found: Requested route ('abcd.colin-2.cf2.paas.alphagov.co.uk') does not exist.
```
- There should be no connection issue in both cases
# Who can review

Anyone but @saliceti
