### PR TITLE
[#100206048] Increase graphite metrics and history

### DIFF
--- a/manifests/templates/aws/stubs/graphite-stub.yml
+++ b/manifests/templates/aws/stubs/graphite-stub.yml
@@ -1,7 +1,7 @@
 jobs:
   - name: graphite
     instances: 1
-    persistent_disk: 20480
+    persistent_disk: 204800
     networks:
     - name: cf1
       static_ips: [ 10.0.10.40 ]

--- a/manifests/templates/deployments/collectd.yml
+++ b/manifests/templates/deployments/collectd.yml
@@ -185,6 +185,8 @@ jobs:
 
 properties:
   <<: (( merge ))
+  collectd:
+    interval: 10
   graphite:
     server: changeme
     prefix: "servers."

--- a/manifests/templates/deployments/collector.yml
+++ b/manifests/templates/deployments/collector.yml
@@ -3,6 +3,11 @@ name: (( merge ))
 jobs:
   - <<: (( merge ))
 
+meta:
+  collector:
+    intervals:
+      default: 10
+
 properties:
   <<: (( merge ))
   collector:
@@ -11,3 +16,8 @@ properties:
     graphite:
       address: changeme
       port: 2003
+    intervals:
+      healthz: (( meta.collector.intervals.default ))
+      local_metrics: (( meta.collector.intervals.default ))
+      nats_ping: (( meta.collector.intervals.default ))
+      varz: (( meta.collector.intervals.default ))

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -35,6 +35,9 @@ jobs:
         - name: "my_storage_schema_2"
           pattern: "metrics$"
           retentions: "15s:7d,1m:21d,15m:5y"
+        - name: "catch_all"
+          pattern: "^.*"
+          retentions: "10s:1d,60s:7d"
       storage_aggregations:
         - name: "my_storage_aggregation"
           pattern: "^my\\.metrics\\.*" # NB: Note the double escapes - this will evaluate to "^my\.metrics\.*"

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -18,7 +18,7 @@ jobs:
 - <<: (( merge ))
 - name: graphite
   instances: 1
-  resource_pool: (( merge || "small_z1" ))
+  resource_pool: (( merge || "large_z1" ))
   default_networks:
   - name: cf1
     static_ips: ~

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -44,6 +44,8 @@ jobs:
           pattern: "metrics$"
           xFilesFactor: "0.1"
           aggregationMethod: "max"
+      cache:
+        max_creates_per_minute: 500
     graphite-web:
       time_zone: Europe/London
       httpd:

--- a/manifests/templates/gce/stubs/graphite-stub.yml
+++ b/manifests/templates/gce/stubs/graphite-stub.yml
@@ -1,7 +1,7 @@
 jobs:
   - name: graphite
     instances: 1
-    persistent_disk: 20480
+    persistent_disk: 204800
     networks:
     - name: cf1
       static_ips: null


### PR DESCRIPTION
# What

In order to gather more information for the performance and soak tests, we need to increase the resolution of the metrics gathered  and also keep them for longer.
## Scope

Currently graphite is setup to keep metrics every 60s for 1 day only. In this PR we will:
- Add a storage schema that matches for all metrics and keeps:
  - metrics every 10s for 1 day
  - metrics every 60s for 7 days
- Change the frequency of collectd metrics to 10s (was 60s)
- Change the frequency of the cf collector metrics to 10s (was 30s)
- statsd was already set to 10s, no change there.
- Increase the default VM size for graphite, to cope better with the load.
- Increase the persistent disk for graphite, to have space for all the metrics.

With these changes, we will get almost 6x more metrics in disk, so we will need some more computational power.
## How to test this?
- Deploy CF with this PR
- check that the metrics for collectd, collector and statsd are capture without gaps. You can easily test it by:
  1. Create an SSH tunnel like this: `ssh <bastion_ip> -l ubuntu -L 3000:<graphite_ip>:3000 -L 8080:<graphite_ip>:80` 
  2. Check [that this graph in this link](http://localhost:8080/render/?width=586&height=308&_salt=1445618044.642&from=-10minutes&target=stats.counters.cfstats.http.requests.api_*_paas_alphagov_co_uk.rate&target=servers.api_z1_0.load.load.shortterm&target=cloudfoundry-pulverize.CloudController.0.*.total_users) has lines without gaps, like here:
     ![download](https://cloud.githubusercontent.com/assets/280032/10699060/1213f000-79ac-11e5-81ca-8c8c30f284d3.png)
  - Optionally: Wait > 24h and check that the metrics are there for more than 1 day.
# Who can review this?

Anyone, but @keymon
