### PR TITLE
[#106191208] Fork graphite-nozzle; prefix statsd metric names

### DIFF
--- a/scripts/deploy_graphite_nozzle.sh
+++ b/scripts/deploy_graphite_nozzle.sh
@@ -19,6 +19,11 @@ cf target -o admin -s admin
 
 git clone https://github.com/CloudCredo/graphite-nozzle go/src/github.com/cloudcredo/graphite-nozzle
 cd go/src/github.com/cloudcredo/graphite-nozzle
+git remote add fork https://github.com/alphagov/graphite-nozzle
+git reset --hard
+git clean -fdx
+git fetch --all
+git checkout fork/106191208-deaggregated_names
 
 # The buildpack only supports go1.4.0-2
 cat <<EOF | python
@@ -53,6 +58,7 @@ cf set-env graphite-nozzle FIREHOSE_PASSWORD "${FIREHOSE_PASS}"
 cf set-env graphite-nozzle SUBSCRIPTION_ID firehose
 cf set-env graphite-nozzle STATSD_PREFIX cfstats.
 cf set-env graphite-nozzle SKIP_SSL_VALIDATION true
+cf set-env graphite-nozzle PREFIX_JOB true
 
 cat <<EOF > graphite-nozzle.json
 [


### PR DESCRIPTION
# What

Use our fork of graphite-nozzle which, when combined with the `PREFIX_JOB`
environment variable, will prefix each metric name with the job that it came
from (e.g. `runner_z1.0`). This will allow us to debug issues like comparing
doppler send and receive counts on different VMs.

I'm going to pull request this upstream, but we're not sure at this stage
whether it will be accepted. So I'm using a fork for the timebeing. We
should review this if we rebuild for beta.

In order to switch to the fork I have added a new remote, ensure that we
have fetched from it, and then checkout detached HEAD against the latest
commit on that remote branch. The `git reset` is needed because we modify
`Godeps.json` and can't checkout a different commit with a dirty tree. The
`git clean` is a safety measure, which we don't strictly need because
`manifest.yml` and `Procfile` aren't checked in, but we might have other
files that prevent changing branches.
# How to test
- checkout this branch
- deploy to an environment
- access Graphite using the SSH tunnel described in #42
- look through the `stats.*.cfstats` namespaces and observe the job name and index in the namespace.
# Who should review

Not @dcarley or @Jonty 
