### PR TITLE
[#106959502] Redis broker integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@ ssh/
 gce/account.json
 *.tfstate
 *.tfstate.backup
+.terraform
 gce/.terraform
 aws/.terraform
 *smoke_test*.json
 manifests/templates/outputs/terraform-outputs-*.yml
 scripts/terraform-outputs-*.sh
-

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bastion:
 	$(eval bastion=$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip))
 
 aws: set-aws apply prepare-provision-aws provision deploy-cf deploy-logsearch
-gce: set-gce apply prepare-provision-gce provision deploy-cf deploy-logsearch
+gce: set-gce apply prepare-provision-gce provision deploy-cf deploy-logsearch deploy-redis
 
 apply-aws: set-aws apply
 apply-gce: set-gce apply
@@ -44,6 +44,7 @@ prepare-provision: bastion
 	    manifests/generate_bosh_manifest.sh \
 	    manifests/generate_deployment_manifest.sh \
 	    manifests/generate_logsearch_manifest.sh \
+	    manifests/generate_redis_manifest.sh \
 	    ubuntu@${bastion}:
 	@scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
 	@PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf-secrets.yml | ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-secrets.yml'
@@ -77,6 +78,11 @@ deploy-logsearch-aws: set-aws deploy-logsearch
 deploy-logsearch-gce: set-gce deploy-logsearch
 deploy-logsearch: check-env-vars bastion
 	@ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/deploy_logsearch.sh ${dir}'
+
+deploy-redis-aws: set-aws deploy-redis
+deploy-redis-gce: set-gce deploy-redis
+deploy-redis: check-env-vars bastion
+	@ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/deploy_redis.sh ${dir}'
 
 confirm-execution:
 	@if test "${SKIP_CONFIRM}" = "" ; then \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ set-gce:
 bastion:
 	$(eval bastion=$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip))
 
-aws: set-aws apply prepare-provision-aws provision deploy-cf deploy-logsearch
+aws: set-aws apply prepare-provision-aws provision deploy-cf deploy-logsearch deploy-redis
 gce: set-gce apply prepare-provision-gce provision deploy-cf deploy-logsearch deploy-redis
 
 apply-aws: set-aws apply

--- a/manifests/generate_redis_manifest.sh
+++ b/manifests/generate_redis_manifest.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+templates=$(dirname $0)/templates
+
+infrastructure=$1
+
+shift
+
+if [ "$infrastructure" != "aws" ] && \
+    [ "$infrastructure" != "gce" ] ; then
+  echo "usage: ./generate_deployment_manifest <aws|gce> [stubs...]"
+  exit 1
+fi
+
+spiff merge \
+  $templates/redis/redis-deployment.yml \
+  $templates/redis/redis-jobs.yml \
+  $templates/redis/redis-infrastructure-${infrastructure}.yml \
+  $templates/redis/stub.yml \
+  $templates/stubs/director-uuid.yml \
+  $templates/outputs/terraform-outputs-${infrastructure}.yml \
+  $templates/cf-secrets.yml \

--- a/manifests/templates/aws/stubs/cf-stub-aws.yml
+++ b/manifests/templates/aws/stubs/cf-stub-aws.yml
@@ -68,7 +68,7 @@ properties:
   databases:
     address: (( jobs.postgres_z1.networks.cf1.static_ips.[0] ))
   syslog_daemon_config:
-    address: 10.0.40.12
+    address: 10.0.40.10
     port: 2514
     transport: relp
 

--- a/manifests/templates/redis/redis-deployment.yml
+++ b/manifests/templates/redis/redis-deployment.yml
@@ -1,0 +1,48 @@
+---
+name: (( "redis-" terraform_outputs.environment ))
+terraform_outputs: (( merge ))
+meta:
+  <<: (( merge ))
+  environment: ~
+  releases:
+  - name: cf-redis
+    version: latest
+  default_env:
+    # Default vcap & root password on deployed VMs (ie c1oudc0w)
+    # Generated using mkpasswd -m sha-512
+    bosh:
+      password: (( merge || "$6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0" ))
+  stemcell: (( merge ))
+
+director_uuid: (( merge ))
+properties: (( merge ))
+
+jobs: (( merge ))
+networks: (( merge ))
+
+releases: (( merge || meta.releases ))
+
+compilation:
+  workers: 4
+  network: default
+  reuse_compilation_vms: true
+  cloud_properties: ~
+
+update:
+  canaries: 1
+  canary_watch_time: 30000-180000
+  update_watch_time: 30000-180000
+  max_in_flight: 4
+
+resource_pools:
+- name: tiny
+  network: default
+  stemcell: (( meta.stemcell ))
+  cloud_properties: ~
+  env: (( merge || meta.default_env ))
+
+- name: redis
+  network: default
+  stemcell: (( meta.stemcell ))
+  cloud_properties: ~
+  env: (( merge || meta.default_env ))

--- a/manifests/templates/redis/redis-infrastructure-aws.yml
+++ b/manifests/templates/redis/redis-infrastructure-aws.yml
@@ -1,0 +1,63 @@
+---
+terraform_outputs: (( merge ))
+meta:
+  zones:
+    z1: (( terraform_outputs.zone0 ))
+    z2: (( terraform_outputs.zone1 ))
+
+  stemcell:
+    name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+    version: latest
+
+  environment: (( merge ))
+
+jobs:
+- name: redis
+  networks:
+  - name: default
+    static_ips:
+    - 10.0.40.51
+
+properties:
+  <<: (( merge ))
+  syslog_aggregator:
+    address: 10.0.40.10
+  cf:
+    nats:
+      host: 10.0.10.11
+
+update: ~
+
+compilation:
+  cloud_properties:
+    instance_type: c3.large
+    availability_zone: (( meta.zones.z1 ))
+
+resource_pools:
+- name: tiny
+  cloud_properties:
+    instance_type: t2.micro
+    ephemeral_disk:
+      size: 10_240
+      type: gp2
+    availability_zone: (( meta.zones.z1 ))
+- name: redis
+  cloud_properties:
+    instance_type: m3.medium
+    ephemeral_disk:
+      size: 10_240
+      type: gp2
+    availability_zone: (( meta.zones.z1 ))
+
+networks:
+- name: default
+  subnets:
+    - range: 10.0.40.0/24
+      gateway: 10.0.40.1
+      dns: [10.0.0.2]
+      reserved:
+      - 10.0.40.2 - 10.0.40.50
+      static:
+      - 10.0.40.51 - 10.0.40.60
+      cloud_properties:
+        subnet: (( terraform_outputs.logsearch1_subnet_id ))

--- a/manifests/templates/redis/redis-infrastructure-gce.yml
+++ b/manifests/templates/redis/redis-infrastructure-gce.yml
@@ -1,0 +1,61 @@
+---
+terraform_outputs: (( merge ))
+name: (( merge ))
+meta:
+  zones:
+    z1: (( terraform_outputs.zone0 ))
+    z2: (( terraform_outputs.zone1 ))
+
+  stemcell:
+    name: bosh-google-kvm-ubuntu-trusty-go_agent
+    version: latest
+
+  environment: (( merge ))
+
+# set static ips to null
+jobs:
+- name: redis
+  networks:
+  - name: default
+    static_ips: null
+
+properties:
+  <<: (( merge ))
+  syslog_aggregator:
+    address: (( "0.logsearch-minimal.default.logsearch-" .meta.environment ".microbosh" ))
+  cf:
+    nats:
+      host: (( "0.nats-z1.cf1.cloudfoundry-" .meta.environment ".microbosh" ))
+  
+update: ~
+
+compilation:
+  cloud_properties:
+    machine_type: n1-highcpu-2
+    availability_zone: (( meta.zones.z1 ))
+
+resource_pools:
+- name: tiny
+  cloud_properties:
+    machine_type: f1-micro
+    root_disk_size_gb: 10
+    root_disk_type: pd-standard
+    availability_zone: (( meta.zones.z1 ))
+- name: redis
+  cloud_properties:
+    machine_type: n1-standard-1
+    root_disk_size_gb: 10
+    root_disk_type: pd-standard
+    availability_zone: (( meta.zones.z1 ))
+
+networks:
+- name: default
+  type: dynamic
+  cloud_properties:
+    network_name: (( terraform_outputs.logsearch1_network_name ))
+    ephemeral_external_ip: false
+    tags:
+      - redis
+      - (( terraform_outputs.environment ))
+      - cf # This tag is needed for nat routing
+

--- a/manifests/templates/redis/redis-jobs.yml
+++ b/manifests/templates/redis/redis-jobs.yml
@@ -1,0 +1,65 @@
+---
+terraform_outputs: (( merge ))
+secrets: (( merge ))
+networks: (( merge ))
+name: (( merge ))
+
+jobs:
+  - name: redis
+    templates:
+    - name: cf-redis-broker
+      release: cf-redis
+    - name: syslog-configurator
+      release: cf-redis
+    instances: 1
+    resource_pool: redis
+    persistent_disk: 10240
+    networks:
+    - name: default
+      static_ips: (( merge ))
+
+  - name: broker-registrar
+    instances: 1
+    lifecycle: errand
+    networks:
+    - name: default
+    resource_pool: tiny
+    templates:
+    - name: broker-registrar
+      release: cf-redis
+
+  - name: broker-deregistrar
+    instances: 1
+    lifecycle: errand
+    networks:
+    - name: default
+    resource_pool: tiny
+    templates:
+    - name: broker-deregistrar
+      release: cf-redis
+
+  - name: smoke-tests
+    instances: 1
+    lifecycle: errand
+    networks:
+    - name: default
+    resource_pool: tiny
+    templates:
+    - name: smoke-tests
+      release: cf-redis
+
+properties: 
+  <<: (( merge ))
+  syslog_aggregator:
+    address: (( merge ))
+    port: 2514
+  cf:
+    api_url: (( "https://api." terraform_outputs.cf_root_domain ))
+    apps_domain: (( terraform_outputs.cf_root_domain ))
+    admin_username: admin
+    admin_password: (( secrets.uaa_admin_password ))
+    nats:
+      host: (( merge ))
+      port: 4222
+      username: nats_user
+      password: (( secrets.nats_password ))

--- a/manifests/templates/redis/stub.yml
+++ b/manifests/templates/redis/stub.yml
@@ -1,0 +1,31 @@
+---
+terraform_outputs: (( merge ))
+secrets: (( merge ))
+
+meta:
+  environment: (( terraform_outputs.environment ))
+  default_env:
+    bosh:
+      password: (( secrets.vcap_password ))
+  broker_host: ~
+  nats_host: ~
+  syslog_host: ~
+
+name: (( "redis-" meta.environment ))
+properties:
+  broker:
+    name: redis
+    host: (( merge ))
+    username: admin
+    password: (( secrets.redis_broker_admin_password || "password" ))
+    host: (( "redis-broker." terraform_outputs.cf_root_domain ))
+  redis:
+    config_command: ""
+    broker:
+      network: default
+      service_name: redis
+      service_instance_limit: 100
+      dedicated_nodes:  null
+      auth:
+        username: admin
+        password: (( secrets.redis_broker_admin_password || "password" ))

--- a/scripts/deploy_graphite_nozzle.sh
+++ b/scripts/deploy_graphite_nozzle.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+if [[ -n $(cf app graphite-nozzle | grep running) ]] ; then
+  echo "Graphite nozzle seems to be running already, skipping deploy..."
+  exit 0
+fi
+
 echo "*** Deploying and starting graphite nozzle..."
 
 CF_ADMIN="$1"

--- a/scripts/deploy_psql_broker.sh
+++ b/scripts/deploy_psql_broker.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if [[ -n $(cf app postgresql-cf-service-broker | grep running) ]] ; then
+  echo "PostgreSQL broker seems to be running already, skipping deploy..."
+  exit 0
+fi
 echo "*** Deploying and registering PostgreSQL broker..."
 
 PSQL_SERVER=`bosh vms | grep postgres/0 | grep -o '10\.[0-9]\+\.[0-9]\+\.[0-9]\+'`

--- a/scripts/deploy_redis.sh
+++ b/scripts/deploy_redis.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+
+set -e # fail on error
+
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+
+
+# Read the platform configuration
+TARGET_PLATFORM=$1
+case $TARGET_PLATFORM in
+  aws)
+    ;;
+  gce)
+    ;;
+  *)
+    echo "Must specify the target platform: gce|aws"
+    exit 1
+    ;;
+esac
+
+export BUNDLE_GEMFILE=$SCRIPT_DIR/Gemfile
+BOSH_CLI="bundle exec bosh"
+
+# Other config
+export PATH=$PATH:/usr/local/bin
+
+# Include the terraform output variables
+. $SCRIPT_DIR/terraform-outputs-${TARGET_PLATFORM}.sh
+
+cd ~
+
+# Generate manifest
+./generate_redis_manifest.sh $TARGET_PLATFORM > ~/redis-manifest.yml
+
+# Deploy redis
+$BOSH_CLI deployment ~/redis-manifest.yml
+time $BOSH_CLI -n deploy
+
+# Register broker
+curl --fail --silent --insecure https://redis.$terraform_output_cf_root_domain > /dev/null || time $BOSH_CLI -n run errand broker-registrar
+
+# Cofigure security
+REDIS_IP=$(/usr/local/bin/bosh vms 2>&1 | awk  '$2 ~ /redis\/0/ {print $8}')
+echo '[{"protocol":"tcp","destination":"'$REDIS_IP'","ports":"1-65535"}]' > redis-sec-group.json
+cf create-security-group redis-security-group redis-sec-group.json
+cf bind-staging-security-group redis-security-group
+cf bind-running-security-group redis-security-group

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -219,6 +219,7 @@ upload_releases() {
     local version=$(echo $r | cut -f 2 -d ,)
     local url=$(echo $r | cut -f 3 -d ,)
     local action=$(echo $r | cut -f 4 -d ,)
+    local directory=$(echo $r | awk -F"/" '{print $NF}' | cut -d"." -f 1)
 
     if bundle exec $SCRIPT_DIR/bosh_list_releases.rb | grep -q "$name/$version"; then
       echo "Release $name version $version already uploaded, skipping"
@@ -226,7 +227,9 @@ upload_releases() {
     else
       if [[ ${action} == "create" ]] ; then
          git_clone ${url} ${version}
-         $BOSH_CLI create release --name ${name} --version ${version}
+         if [[ $(grep -R ${version} ~/${directory}/dev_releases/) == "" ]]; then
+           $BOSH_CLI create release --name ${name} --version ${version}
+         fi
          url=""
       fi
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -45,6 +45,7 @@ collectd,ec9de5dc63715237688c3b27154c86a0c22b3aef,https://github.com/alphagov/co
 grafana,44564533c9d4d656bdcd5633b808f0bf6fb177ae,https://github.com/vito/grafana-boshrelease.git,create
 logsearch,23.0.0,https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=23.0.0
 logsearch-for-cloudfoundry,7,https://logsearch-for-cloudfoundry-boshrelease.s3.amazonaws.com/boshrelease-logsearch-for-cloudfoundry-7.tgz
+redis,420,https://bosh.io/d/github.com/pivotal-cf/cf-redis-release?v=420
 "
 
 # Dependencies versions


### PR DESCRIPTION
# What

[Deploy a key/value store instance that can be used in the trial CF](https://www.pivotaltracker.com/story/show/106959502)
Redis broker for CF to allow trial users to use a key-value store. We are using [cf-redis-release](https://github.com/pivotal-cf/cf-redis-release.git) to provide the broker. 
Summary of work:
- modifications of Makefile to include Redis deployment
- templates to generate relevant aws and gce deployment manifest
- generate_redis_mainifest.sh script 
- small changes to provision.sh to include Redis release during deployment
- included smoke test 
# How to review

```
make gce DEPLOY_ENV=your_name
make aws DEPLOY_ENV=your_name
```

then ssh to bastion host and run 

```
bosh run errand smoke-test
```
# Who can review

Anyone but @mtekel or @combor.
