### PR TITLE
[#106739952] Deploy diego on CF (2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,4 +123,4 @@ show:
 ssh-aws: set-aws ssh
 ssh-gce: set-gce ssh
 ssh: check-env-vars bastion
-	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion}
+	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} ${CMD}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ set-gce:
 	$(eval dir=gce)
 	$(eval apply_suffix=-var gce_account_json="`tr -d '\n' < account.json`")
 bastion:
-	$(eval bastion=$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate bastion_ip))
+	$(eval bastion=$(shell DEPLOY_ENV=${DEPLOY_ENV} ./scripts/get_bastion_host.sh ${dir}))
 
 aws: set-aws apply prepare-provision-aws provision deploy-cf deploy-logsearch
 gce: set-gce apply prepare-provision-gce provision deploy-cf deploy-logsearch

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,6 @@ delete-stemcell: bastion
 	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} \
 			'bosh stemcells | grep -v -e + | grep -v -e Name -e "Stemcells total" -e "Currently in-use" | cut -d "|" -f 2,4 | tr "|" " " | grep -v ^$$ | while read -r stemcell; do bosh -n delete stemcell $$stemcell --force; done'
 
-delete-route-gce: bastion
-	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} "/bin/bash ./scripts/gce-delete-fixed-ip.sh ${DEPLOY_ENV}"
-
 destroy-terraform-aws: confirm-execution set-aws destroy-terraform
 destroy-terraform-gce: confirm-execution set-gce destroy-terraform
 destroy-terraform:

--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -5,3 +5,19 @@ resource "aws_route53_record" "wildcard" {
   ttl = "60"
   records = ["${aws_elb.router.dns_name}"]
 }
+
+resource "aws_route53_record" "bastion" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-bastion.${var.dns_zone_name}."
+  type = "A"
+  ttl = "60"
+  records = ["${aws_instance.bastion.public_ip}"]
+}
+
+resource "aws_route53_record" "bosh" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-bosh.${var.dns_zone_name}."
+  type = "A"
+  ttl = "60"
+  records = ["${aws_eip.bosh.public_ip}"]
+}

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -5,3 +5,20 @@ resource "google_dns_record_set" "wildcard" {
   ttl = "60"
   rrdatas = ["${google_compute_forwarding_rule.router_https.ip_address}"]
 }
+
+resource "google_dns_record_set" "bastion" {
+  managed_zone = "${var.dns_zone_id}"
+  name = "${var.env}-bastion.${var.dns_zone_name}."
+  type = "A"
+  ttl = "60"
+  rrdatas = ["${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}"]
+}
+
+resource "google_dns_record_set" "bosh" {
+  managed_zone = "${var.dns_zone_id}"
+  name = "${var.env}-bosh.${var.dns_zone_name}."
+  type = "A"
+  ttl = "60"
+  rrdatas = ["${google_compute_address.bosh.address}"]
+}
+

--- a/scripts/get_bastion_host.sh
+++ b/scripts/get_bastion_host.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+if [ -z "$DEPLOY_ENV" -o -z "$1" ]; then
+  cat << EOF
+Prints the bastion ip or hostname.
+
+Usage:
+  DEPLOY_ENV=... $0 <gce|aws>
+EOF
+  exit 0
+fi
+
+TARGET_PLATFORM=$1
+
+tfstate=$(dirname $0)/../$TARGET_PLATFORM/$DEPLOY_ENV.tfstate
+bastion_ip=$(terraform output -state=$tfstate bastion_ip 2>/dev/null)
+
+if [ "$bastion_ip" ]; then
+  result=$bastion_ip
+else
+  if [ "$TARGET_PLATFORM" == "aws" ]; then
+    result="$DEPLOY_ENV-bastion.cf.paas.alphagov.co.uk"
+  elif [ "$TARGET_PLATFORM" == "gce" ]; then
+    result="$DEPLOY_ENV-bastion.cf2.paas.alphagov.co.uk"
+  else
+    echo "Error: $0: Unknown target platform: $TARGET_PLATFORM" 1>&2
+    exit 1
+  fi
+  echo "Warning: $0: Failing retrieving bastion ip from bosh, failover to DNS: $result" 1>&2
+fi
+
+echo $result


### PR DESCRIPTION
# What

We want to start testing deployments on Diego, as the new runtime for cloudfoundry.

We must provide a way to deploy Diego in our setup.
# Context

We investigate how Diego must be deployed and configure.

We follow the instructions in https://github.com/cloudfoundry-incubator/diego-release.
## Upgrade of CF

We upgrade Cloudfoundry to v218, as the [closest version with the newest diego release](https://github.com/cloudfoundry-incubator/diego-cf-compatibility/blob/8b22d26dbe51e931c569e43d45263d9926d41320/compatibility-v2.csv).
- Versions:
  - Diego: 0.1430.0
  - Garden: 0.305.0
  - CF: v218
- Disable SSL in consul, just to avoid having to create certificates.
- Patch again [cf-release to include several required changes, specially for CF](https://github.com/alphagov/cf-release/tree/gds-paas-v218)

To be able to deploy on GCE, we need to use a custom version of the consul template.
## Installing diego release
- We provide a script `./scripts/deploy_diego.sh` which will clone the diego release repo, generate the manifest and deploy diego.
- We provide templates in [`manifests/templates/diego`](https://github.com/alphagov/cf-terraform/blob/106739952_deploy_diego_on_cf/manifests/templates/diego/) and the script [`manifests/generate_diego_release.sh`](https://github.com/alphagov/cf-terraform/blob/106739952_deploy_diego_on_cf/manifests/generate_diego_release.sh) which will create the diego template.
  - This template deploys `cell_z1` (runtime vms) and  the rest of services in `colocated_services_z1`
  - Machine types require some tunning.
  - We based all the properties on the defaults [from `bosh-lite` example](https://github.com/cloudfoundry-incubator/diego-release/blob/0.1430.0-gds-paas/manifest-generation/bosh-lite-stubs/property-overrides.yml)
# How to test this:
1. Deploy CF as usual: `make <aws|gce> DEPLOY_ENV=...`
2. Deploy diego by running `./scripts/deploy_diego.sh`
3. Deploy an app by following [this instructions](https://github.com/cloudfoundry-incubator/diego-release/#pushing-to-diego). In summary:
   1. Install diego plugin: `cf add-plugin-repo CF-Community http://plugins.cloudfoundry.org &&  cf install-plugin Diego-Enabler -r CF-Community`
   2. `cf push appname --no-start &&  cf enable-diego appname &&  cf start appname`
# Known issues

This didn't work directly with the official release on GCE because the [consul agents won't start](https://github.com/cloudfoundry-incubator/consul-release/issues/4). 

As a workaround, we use a [custom patch version of the consul_agent based on the consul-release](https://github.com/keymon/consul-release/tree/bugfix/consul_ctl_not_check_servers_by_ip)

Other issue is that deployment of big apps fail on GCE (requires further investigation).
# Who can review this

Anyone but @Jonty or @keymon
