### PR TITLE
[#fixbuild] Use bash for script get_bastion_host.sh

### DIFF
--- a/scripts/get_bastion_host.sh
+++ b/scripts/get_bastion_host.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z "$DEPLOY_ENV" -o -z "$1" ]; then
   cat << EOF


### PR DESCRIPTION
On machines where the default shell script is not bash, this script
can fail. It is better to explicitly specify the interpreter.

[Example failure](https://deploy.tools.paas.alphagov.co.uk/view/%20trial/job/trial-cf-smoke-test-aws/12/console):

```
Retrieving Terraform state
./scripts/get_bastion_host.sh: 27: [: aws: unexpected operator
./scripts/get_bastion_host.sh: 29: [: aws: unexpected operator
Error: ./scripts/get_bastion_host.sh: Unknown target platform: aws
smoke_test/smoke_test.json.sh \
        trial cf.paas.alphagov.co.uk \
        admin `PASSWORD_STORE_DIR=~/.paas-pass pass jenkins/cloudfoundry/cf_admin_password` > \
        smoke_test/smoke_test.json
```
