### PR TITLE
[#107051212] Redirect HTTP traffic to HTTPS on the routers

### DIFF
--- a/manifests/templates/deployments/https_redirect.yml
+++ b/manifests/templates/deployments/https_redirect.yml
@@ -1,0 +1,39 @@
+nginx:
+  name: nginx
+  release: nginx
+
+jobs:
+  - <<: (( merge ))
+  - name: router_z1
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( nginx ))
+  - name: router_z2
+    <<: (( merge ))
+    templates:
+      - <<: (( merge ))
+      - (( nginx ))
+
+properties:
+  <<: (( merge ))
+  nginx_conf: |
+    worker_processes  1;
+    error_log /dev/stdout   info;
+    events {
+      worker_connections  1024;
+    }
+    http {
+      client_body_temp_path /tmp/nginx_body_cache;
+      proxy_temp_path /tmp/nginx_proxy_cache;
+      fastcgi_temp_path /tmp/nginx_fastcgi_cache;
+      uwsgi_temp_path /tmp/nginx_uwsgi_cache;
+      scgi_temp_path /tmp/nginx_scgi_cache;
+      keepalive_timeout 0;
+      server {
+        listen 80;
+        return 301 https://$host$request_uri;
+        access_log /dev/stdout;
+        error_log /dev/stdout;
+      }
+    }

--- a/manifests/templates/stubs/cf-stub.yml
+++ b/manifests/templates/stubs/cf-stub.yml
@@ -38,6 +38,7 @@ properties:
     db_encryption_key: (( secrets.cc_db_encryption_key ))
     min_cli_version: '6.1.0'
     min_recommended_cli_version: '6.10.0'
+    external_protocol: https
   nats:
     user: nats_user
     password: (( secrets.nats_password ))
@@ -46,6 +47,7 @@ properties:
     memory_mb: 4096
   router:
     enable_ssl: true
+    port: 8090 # We bind router on port 8090 as it's not wanted, but we can't disable it
     ssl_cert: (( secrets.router_ssl_cert ))
     ssl_key: (( secrets.router_ssl_key ))
     cipher_suites: TLS_RSA_WITH_RC4_128_SHA:TLS_RSA_WITH_AES_128_CBC_SHA

--- a/manifests/templates/stubs/releases.yml
+++ b/manifests/templates/stubs/releases.yml
@@ -9,3 +9,5 @@ releases:
   version: latest
 - name: collectd
   version: latest
+- name: nginx
+  version: latest

--- a/scripts/deploy_psql_broker.sh
+++ b/scripts/deploy_psql_broker.sh
@@ -51,6 +51,6 @@ URL=`cf app postgresql-cf-service-broker | grep urls: | awk '{print $2}'`
 # Only register if not done already
 cf service-brokers | grep -q ${URL}
 if [[ ! $? == 0 ]] ; then
-  cf create-service-broker postgresql-cf-service-broker user ${PSQL_ADMIN_PASS} http://${URL}
+  cf create-service-broker postgresql-cf-service-broker user ${PSQL_ADMIN_PASS} https://${URL}
   cf enable-service-access PostgreSQL -p "Basic PostgreSQL Plan"
 fi

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -46,6 +46,7 @@ grafana,44564533c9d4d656bdcd5633b808f0bf6fb177ae,https://github.com/vito/grafana
 logsearch,23.0.0,https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=23.0.0
 logsearch-for-cloudfoundry,7,https://logsearch-for-cloudfoundry-boshrelease.s3.amazonaws.com/boshrelease-logsearch-for-cloudfoundry-7.tgz
 redis,420,https://bosh.io/d/github.com/pivotal-cf/cf-redis-release?v=420
+nginx,667cc1a0f9117bdb4b217ee2b76dc20e61371c02,https://s3.amazonaws.com/nginx-release/nginx-2.tgz
 "
 
 # Dependencies versions


### PR DESCRIPTION
gorouter has no capability to redirect HTTP traffic to HTTPS. In order
to work around this we install an nginx release on the routers listening
on port 80, while reconfiguring gorouter to listen on port 8090 (out of
the way). It can't be reconfigured to disable listening on a plain HTTP
port.

The nginx release is from cf-community:
https://github.com/cloudfoundry-community/nginx-release

CF validates that an app has correctly started by polling it via the
full HTTP routing pipeline - this breaks when we're redirecting port 80,
as it doesn't expect to get a 301 response code. By specifying
`external_protocol` as HTTPS we forcing CF to use 443 for health
checks.

This commit also adds a deployment `https_redirect.yml` template
as nginx needs to be colocated on the same machine as the routers, which
are the ELB targets.

This commit depends on PR #2 in our cf-release fork in order to allow
overriding the gorouter port:
alphagov/cf-release#2

Initially we investigated a cf community HAproxy release that has
built-in functionality for redirecting all HTTP requests to HTTPS.
After a substantial amount of effort we completely failed to get it to
work as the final release appeared to be malformed, and the development
release installed its templates incorrectly as "haproxy". Additionally
the misnamed templates lead to concerns about conflicts with the haproxy
release packaged by cf-release. Nginx was simple to install and
configure, and is guaranteed not to cause problems with other
components.

https://github.com/cloudfoundry-community/cf-haproxy-boshrelease
