### PR TITLE
[#106843508] Expose graphite to office IPs on GCE and AWS

### DIFF
--- a/aws/dns-records.tf
+++ b/aws/dns-records.tf
@@ -21,3 +21,11 @@ resource "aws_route53_record" "bosh" {
   ttl = "60"
   records = ["${aws_eip.bosh.public_ip}"]
 }
+
+resource "aws_route53_record" "grafana" {
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.env}-grafana.${var.dns_zone_name}."
+  type = "CNAME"
+  ttl = "60"
+  records = ["${aws_elb.graphite.dns_name}"]
+}

--- a/aws/graphite_elb.tf
+++ b/aws/graphite_elb.tf
@@ -1,0 +1,29 @@
+resource "aws_elb" "graphite" {
+  name = "${var.env}-graphite-elb"
+  subnets = ["${aws_subnet.infra.*.id}"]
+  idle_timeout = "${var.elb_idle_timeout}"
+  cross_zone_load_balancing = "true"
+  security_groups = [
+    "${aws_security_group.graphite.id}",
+  ]
+
+  health_check {
+    target = "TCP:80"
+    interval = "${var.health_check_interval}"
+    timeout = "${var.health_check_timeout}"
+    healthy_threshold = "${var.health_check_healthy}"
+    unhealthy_threshold = "${var.health_check_unhealthy}"
+  }
+  listener {
+    instance_port = 80
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+  listener {
+    instance_port = 3000
+    instance_protocol = "http"
+    lb_port = 3000
+    lb_protocol = "http"
+  }
+}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -46,6 +46,10 @@ output "elb_name" {
 	value = "${aws_elb.router.name}"
 }
 
+output "graphite_elb_name" {
+  value = "${aws_elb.graphite.name}"
+}
+
 output "cf_root_domain" {
 	value = "${var.env}.${var.dns_zone_name}"
 }

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -194,3 +194,48 @@ resource "aws_security_group" "web" {
     Name = "${var.env}-cf-web"
   }
 }
+
+resource "aws_security_group" "graphite" {
+  name = "${var.env}-graphite"
+  description = "Security group for graphite that allows web traffic from the office and jenkins"
+  vpc_id = "${aws_vpc.default.id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${split(",", var.office_cidrs)}",
+      "${aws_instance.bastion.public_ip}/32",
+      "${var.jenkins_elastic}"
+    ]
+    security_groups = [
+      "${aws_security_group.bosh_vm.id}"
+    ]
+  }
+
+  ingress {
+    from_port = 3000
+    to_port   = 3000
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${split(",", var.office_cidrs)}",
+      "${aws_instance.bastion.public_ip}/32",
+      "${var.jenkins_elastic}"
+    ]
+    security_groups = [
+      "${aws_security_group.bosh_vm.id}"
+    ]
+  }
+
+  tags {
+    Name = "${var.env}-graphite"
+  }
+}

--- a/gce/dns-records.tf
+++ b/gce/dns-records.tf
@@ -22,3 +22,10 @@ resource "google_dns_record_set" "bosh" {
   rrdatas = ["${google_compute_address.bosh.address}"]
 }
 
+resource "google_dns_record_set" "grafana" {
+  managed_zone = "${var.dns_zone_id}"
+  name = "${var.env}-grafana.${var.dns_zone_name}."
+  type = "A"
+  ttl = "60"
+  rrdatas = ["${google_compute_address.graphite.address}"]
+}

--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -70,3 +70,19 @@ resource "google_compute_firewall" "web" {
     ports = [ 80, 443 ]
   }
 }
+
+resource "google_compute_firewall" "graphite" {
+  name = "${var.env}-graphite"
+  description = "Security group for graphite that allows web traffic from the office and jenkins"
+  network = "${google_compute_network.bastion.name}"
+
+  source_ranges = [ "${split(",", var.office_cidrs)}",
+                    "${var.bastion_cidr}",
+                    "${var.jenkins_elastic}" ]
+  target_tags = [ "graphite1" ]
+
+  allow {
+    protocol = "tcp"
+    ports = [ 80, 3000 ]
+  }
+}

--- a/gce/graphite_lb.tf
+++ b/gce/graphite_lb.tf
@@ -1,0 +1,21 @@
+resource "google_compute_target_pool" "graphite" {
+  name = "${var.env}-graphite-lb"
+}
+
+resource "google_compute_address" "graphite" {
+  name = "${var.env}-graphite-lb"
+}
+
+resource "google_compute_forwarding_rule" "graphite_http" {
+  name = "${var.env}-graphite-lb-http"
+  ip_address = "${google_compute_address.graphite.address}"
+  target = "${google_compute_target_pool.graphite.self_link}"
+  port_range = 80
+}
+
+resource "google_compute_forwarding_rule" "graphite_3000" {
+  name = "${var.env}-graphite-lb-3000"
+  ip_address = "${google_compute_address.graphite.address}"
+  target = "${google_compute_target_pool.graphite.self_link}"
+  port_range = 3000
+}

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -46,6 +46,10 @@ output "router_pool_name" {
 	value = "${google_compute_target_pool.router.name}"
 }
 
+output "graphite_pool_name" {
+	value = "${google_compute_target_pool.graphite.name}"
+}
+
 output "cf_root_domain" {
 	value = "${var.env}.${var.dns_zone_name}"
 }

--- a/manifests/templates/aws/stubs/graphite-stub.yml
+++ b/manifests/templates/aws/stubs/graphite-stub.yml
@@ -1,3 +1,20 @@
+terraform_outputs: (( merge ))
+meta:
+  zones:
+    z1: (( terraform_outputs.zone0 ))
+    z2: (( terraform_outputs.zone1 ))
+
+resource_pools:
+  - name: graphite_z1
+    cloud_properties:
+      instance_type: m3.large
+      ephemeral_disk:
+        size: 65_536
+        type: gp2
+      availability_zone: (( meta.zones.z1 ))
+      elbs:
+      - (( terraform_outputs.graphite_elb_name ))
+
 jobs:
   - name: graphite
     instances: 1

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -1,3 +1,4 @@
+terraform_outputs: (( merge ))
 meta:
   release:
     name: cf
@@ -13,12 +14,31 @@ meta:
       release: (( meta.release.name ))
     - name: grafana
       release: grafana
+  zones:
+    z1: (( terraform_outputs.zone0 ))
+    z2: (( terraform_outputs.zone1 ))
+
+  default_env:
+    # Default vcap & root password on deployed VMs (ie c1oudc0w)
+    # Generated using mkpasswd -m sha-512
+    bosh:
+      password: (( merge || "$6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0" ))
+
+  stemcell: (( merge ))
+
+resource_pools:
+  - <<: (( merge ))
+  - name: graphite_z1
+    network: (( merge || "cf1" ))
+    stemcell: (( meta.stemcell ))
+    env: (( merge || meta.default_env ))
+    cloud_properties: (( merge ))
 
 jobs:
 - <<: (( merge ))
 - name: graphite
   instances: 1
-  resource_pool: (( merge || "large_z1" ))
+  resource_pool: (( merge || "graphite_z1" ))
   default_networks:
   - name: cf1
     static_ips: ~

--- a/manifests/templates/gce/stubs/cf-stub-gce.yml
+++ b/manifests/templates/gce/stubs/cf-stub-gce.yml
@@ -56,13 +56,24 @@ networks:
         - (( name ))
       target_pool: (( terraform_outputs.router_pool_name ))
 
+  - name: graphite1
+    type: dynamic
+    cloud_properties:
+      network_name: (( terraform_outputs.cf1_network_name ))
+      ephemeral_external_ip: false
+      tags:
+        - cf
+        - (( terraform_outputs.environment ))
+        - (( name ))
+      target_pool: (( terraform_outputs.graphite_pool_name ))
+
 properties:
   graphite:
-    server: (( "0.graphite.cf1." .name ".microbosh" ))
+    server: (( "0.graphite.graphite1." .name ".microbosh" ))
   domain: (( terraform_outputs.environment ".cf2.paas.alphagov.co.uk" ))
   collector:
     graphite:
-      address: (( "0.graphite.cf1." .name ".microbosh" ))
+      address: (( "0.graphite.graphite1." .name ".microbosh" ))
   template_only:
     gce:
       availability_zone: (( terraform_outputs.zone0 ))
@@ -98,3 +109,5 @@ resource_pools:
     network: router1
   - name: router_z2
     network: router2
+  - name: graphite_z1
+    network: graphite1

--- a/manifests/templates/gce/stubs/graphite-stub.yml
+++ b/manifests/templates/gce/stubs/graphite-stub.yml
@@ -1,7 +1,21 @@
+terraform_outputs: (( merge ))
+meta:
+  zones:
+    z1: (( terraform_outputs.zone0 ))
+    z2: (( terraform_outputs.zone1 ))
+
+resource_pools:
+  - name: graphite_z1
+    cloud_properties:
+      machine_type: n1-highcpu-2
+      root_disk_size_gb: 20
+      root_disk_type: pd-standard
+      zone: (( meta.zones.z1 ))
+
 jobs:
   - name: graphite
     instances: 1
     persistent_disk: 204800
     networks:
-    - name: cf1
+    - name: graphite1
       static_ips: null


### PR DESCRIPTION
[#106843508 Monitoring dashboard for the trial CF platform](https://www.pivotaltracker.com/story/show/106843508)
# What

We want to have a dashboard of the platform using metrics from graphite and grafana. Between different options we decided to implement a external LB to expose the services, restricted using FW to the office IPs.
# Context

This PR shall be reviewed in this context:
- I want to setup a new LB, DNS and security group to expose graphite and grafana to the office and jenkins IPs, both on GCE and AWS.
- I want to setup the Graphite jobs (aka VMs) to self register to the LB during deployment using the Bosh CPI capabilities in each platform, in a similar way as the router does.
# How to test this PR?
1. Deploy environments in both GCE and AWS
2. Try to connect from the office to:
   - AWS graphite: http://DEPLOY_ENV-grafana.cf.paas.alphagov.co.uk
   - AWS grafana: http://DEPLOY_ENV-grafana.cf.paas.alphagov.co.uk:3000
   - GCE graphite: http://DEPLOY_ENV-grafana.cf2.paas.alphagov.co.uk
   - GCE graphite: http://DEPLOY_ENV-grafana.cf2.paas.alphagov.co.uk:3000
3. Check that the ports are not accesible from somewhere else.
# Who can review this?

Anyone but @alext or @keymon
