### PR TITLE
[#106843508] Fix graphite AWS security group.

### DIFF
--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -208,8 +208,8 @@ resource "aws_security_group" "graphite" {
   }
 
   ingress {
-    from_port = 8080
-    to_port   = 8080
+    from_port = 80
+    to_port   = 80
     protocol  = "tcp"
     cidr_blocks = [
       "${split(",", var.office_cidrs)}",


### PR DESCRIPTION
The ELB is configured to listen on port 80 for graphite (and 3000 for
grafana), but the security group rule was configured for port 8080
meaning that external access to graphite was being blocked.
