### PR TITLE
[#106843508] Add grafana dashboards

### DIFF
--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -50,6 +50,10 @@ output "graphite_elb_name" {
   value = "${aws_elb.graphite.name}"
 }
 
+output "grafana_dns_name" {
+  value = "${aws_route53_record.grafana.fqdn}"
+}
+
 output "cf_root_domain" {
 	value = "${var.env}.${var.dns_zone_name}"
 }

--- a/scripts/deploy_cf.sh
+++ b/scripts/deploy_cf.sh
@@ -57,6 +57,9 @@ cf_post_deploy() {
   time bash $SCRIPT_DIR/deploy_graphite_nozzle.sh \
     admin $(get_cf_secret secrets/uaa_admin_password) \
     graphite-nozzle $(get_cf_secret secrets/uaa_clients_firehose_password)
+  # Deploy grafana dashboards
+  time bash $SCRIPT_DIR/deploy_grafana_dashboards.sh \
+    $terraform_output_grafana_dns_name
 }
 
 cf_compile_manifest

--- a/scripts/deploy_grafana_dashboards.sh
+++ b/scripts/deploy_grafana_dashboards.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+. $(dirname $0)/grafana-lib.sh
+
+GRAPHITE_HOST=$1
+GRAFANA_URL=http://${GRAPHITE_HOST}:3000
+shift
+
+DATASOURCE_URL=http://127.0.0.1
+DATASOURCE_NAME=graphite
+DATASOURCE_TYPE=graphite
+
+if grafana_has_data_source ${DATASOURCE_NAME}; then
+  info "Grafana: Data source ${DATASOURCE_NAME} already exists"
+else
+  if grafana_create_data_source ${DATASOURCE_NAME} ${DATASOURCE_TYPE} ${DATASOURCE_URL}; then
+    success "Grafana: Data source ${DATASOURCE_NAME} created"
+  else
+    error "Grafana: Data source ${DATASOURCE_NAME} could not be created"
+  fi
+fi
+
+for dashboard in $(dirname $0)/grafana_dashboards/*.json; do
+  info "Grafana: Uploading dashboard ${dashboard##*/}"
+  grafana_upload_dashboard $dashboard
+done

--- a/scripts/grafana-lib.sh
+++ b/scripts/grafana-lib.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Used for this script to talk to the Grafana API
+GRAFANA_URL=http://localhost:3000
+COOKIEJAR="/tmp/grafana_session_$$"
+
+function grafana_url {
+  echo -e ${GRAFANA_URL}/api/
+}
+
+function success {
+  echo "$(tput setaf 2)""$*""$(tput sgr0)"
+}
+
+function info {
+  echo "$(tput setaf 3)""$*""$(tput sgr0)"
+}
+
+function error {
+  echo "$(tput setaf 1)""$*""$(tput sgr0)" 1>&2
+  exit 1
+}
+
+function setup_grafana_session {
+  username=${1-admin}; shift
+  password=${1-admin}; shift
+  if ! curl -H 'Content-Type: application/json;charset=UTF-8' \
+    --data-binary "{\"user\":\"$username\",\"email\":\"\",\"password\":\"$password\"}" \
+    --cookie-jar "$COOKIEJAR" \
+    "${GRAFANA_URL}/login" > /dev/null 2>&1 ; then
+    echo
+    error "Grafana Session: Couldn't store cookies at ${COOKIEJAR}"
+  fi
+}
+
+function grafana_has_data_source {
+  setup_grafana_session
+  curl --silent --cookie "$COOKIEJAR" "${GRAFANA_URL}/api/datasources" \
+    | grep "\"name\":\"${1}\"" --silent
+}
+
+function grafana_create_data_source {
+  name=$1; shift
+  type=$1; shift
+  url=$1; shift
+  user=$1; shift
+  password=$1; shift
+  database=$1; shift
+
+  setup_grafana_session
+  curl --cookie "$COOKIEJAR" \
+       -X POST \
+       --silent \
+       -H 'Content-Type: application/json;charset=UTF-8' \
+       --data-binary "{\"name\":\"${name}\",\"type\":\"${type}\",\"url\":\"${url}\",\"access\":\"proxy\",\"database\":\"${database}\",\"user\":\"${user}\",\"password\":\"${password}\",\"isDefault\":true}" \
+       "${GRAFANA_URL}/api/datasources" 2>&1 | grep 'Datasource added' --silent;
+}
+
+function grafana_upload_dashboard {
+  file=$1; shift
+
+  setup_grafana_session
+  curl --cookie "$COOKIEJAR" \
+       -X POST \
+       --silent \
+       -H 'Content-Type: application/json;charset=UTF-8' \
+       -d "{\"overwrite\": true, \"dashboard\": $(sed '0,/"id":.*$/s///'  "$file")}" \
+       "${GRAFANA_URL}/api/dashboards/db" 2>&1 | grep 'success' --silent
+}

--- a/scripts/grafana_dashboards/cf_services_metrics.json
+++ b/scripts/grafana_dashboards/cf_services_metrics.json
@@ -1,0 +1,451 @@
+{
+  "id": 6,
+  "title": "CF metrics",
+  "originalTitle": "CF metrics",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "warden response time",
+              "yaxis": 2
+            }
+          ],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(averageSeries(nonNegativeDerivative(cloudfoundry-*.DEA.*.*.total_warden_response_time_in_ms)), 'warden response time')",
+              "textEditor": false
+            },
+            {
+              "target": "aliasByNode(sumSeries(cloudfoundry-*.DEA.*.*.dea_registry_starting),-1)"
+            },
+            {
+              "hide": false,
+              "target": "aliasByNode(sumSeries(cloudfoundry-*.DEA.*.*.dea_registry_running),-1)"
+            },
+            {
+              "hide": false,
+              "target": "aliasByNode(sumSeries(cloudfoundry-*.DEA.*.*.dea_registry_stopping),-1)"
+            },
+            {
+              "target": "aliasByNode(sumSeries(cloudfoundry-*.DEA.*.*.dea_registry_stopping),-1)"
+            },
+            {
+              "target": "aliasByNode(sumSeries(cloudfoundry-*.DEA.*.*.dea_registry_stopping),-1)"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "DEA stats",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        }
+      ],
+      "title": "Row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(cloudfoundry-*.CloudController.*.*.cc.job_queue_length.total, 'Cloud Controller Job Queue Total')"
+            },
+            {
+              "target": "alias(cloudfoundry-*.CloudController.*.*.cc.requests.outstanding, 'Cloud Controller Outstanding requests')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Cloud Controller metrics",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Cloud Controller Job Queue Total",
+              "yaxis": 1
+            },
+            {
+              "alias": "Received Heartbeats",
+              "yaxis": 2
+            }
+          ],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(cloudfoundry-*.HM9000.*.*.HM9000.HM9000.NumberOfAppsWithAllInstancesReporting, 'HM900 Apps with all instances')"
+            },
+            {
+              "target": "alias(cloudfoundry-*.HM9000.*.*.HM9000.HM9000.NumberOfAppsWithMissingInstances, 'HM900 Apps with missing instances')"
+            },
+            {
+              "target": "alias(cloudfoundry-*.HM9000.*.*.HM9000.HM9000.NumberOfDesiredApps, 'HM900 Desired apps')"
+            },
+            {
+              "target": "alias(cloudfoundry-*.HM9000.*.*.HM9000.HM9000.NumberOfDesiredAppsPendingStaging, 'Desired Apps pending staging')"
+            },
+            {
+              "target": "alias(cloudfoundry-*.HM9000.*.*.HM9000.HM9000.NumberOfUndesiredRunningApps, 'Undesired apps')"
+            },
+            {
+              "target": "alias(nonNegativeDerivative(cloudfoundry-*.HM9000.*.*.HM9000.HM9000.ReceivedHeartbeats), 'Received Heartbeats')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "HM9000 metrics",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Cloud Controller Job Queue Total",
+              "yaxis": 1
+            },
+            {
+              "alias": "Received Heartbeats",
+              "yaxis": 2
+            }
+          ],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "alias(scaleToSeconds(nonNegativeDerivative(sumSeries(cloudfoundry-*.Router.*.*.router.requests.app)), 1), 'App requests')"
+            },
+            {
+              "target": "alias(scaleToSeconds(nonNegativeDerivative(sumSeries(cloudfoundry-*.Router.*.*.router.requests.CloudController)), 1), 'Cloud controller requests')"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Router requests",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Cloud Controller Job Queue Total",
+              "yaxis": 1
+            },
+            {
+              "alias": "Received Heartbeats",
+              "yaxis": 2
+            }
+          ],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "aliasByNode(scaleToSeconds(nonNegativeDerivative(cloudfoundry-*.MetronAgent.*.*.MetronAgent.DropsondeUnmarshaller.logMessageTotal), 1), 3)"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Metron Logs received",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        }
+      ],
+      "title": "New row"
+    }
+  ],
+  "nav": [
+    {
+      "collapse": false,
+      "enable": true,
+      "notice": false,
+      "now": true,
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "type": "timepicker"
+    }
+  ],
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "schemaVersion": 6,
+  "version": 1,
+  "links": []
+}

--- a/scripts/grafana_dashboards/dea_metrics.json
+++ b/scripts/grafana_dashboards/dea_metrics.json
@@ -1,0 +1,314 @@
+{
+  "id": 8,
+  "title": "DEA Metrics",
+  "originalTitle": "DEA Metrics",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "aliasByNode(cloudfoundry-*.DEA.*.*.cpu_load_avg, -2)"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "All CPU Load",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": 0,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "aliasByNode(cloudfoundry-*.DEA.*.*.mem_used_bytes, -2)"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "All Nodes Memory Used",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "bytes",
+            "short"
+          ]
+        }
+      ],
+      "title": "Row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": 100,
+            "leftMin": 0,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "target": "aliasByNode(asPercent(cloudfoundry-*.DEA.*.*.available_disk_ratio, 1), -2)"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "All Disk space free",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "percent",
+            "short"
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": null,
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "leftLogBase": 1,
+            "leftMax": null,
+            "leftMin": null,
+            "rightLogBase": 1,
+            "rightMax": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "no title (click here)",
+          "tooltip": {
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ]
+        }
+      ],
+      "title": "New row"
+    }
+  ],
+  "nav": [
+    {
+      "collapse": false,
+      "enable": true,
+      "notice": false,
+      "now": true,
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "type": "timepicker"
+    }
+  ],
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "schemaVersion": 6,
+  "version": 5,
+  "links": []
+}


### PR DESCRIPTION
## What

This adds some monitoring dashboards to grafana to be displayed on monitors during the trial. The initial dashboards are pretty minimal, and it's expected that the contents of these will be refined as needed.
## How to test

Dashboards will be available in grafana (`http://${DEPLOY_ENV}-grafana.cf.paas.alphagov.co.uk:3000/`) after provisioning.
## Who can review

Anyone but @actionjack or @alext who worked on this PR.
