### PR TITLE
[#107588012] Bugfix/fix remove logstash errors in logsearch-for-cloudfoundry

### DIFF
--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -67,7 +67,7 @@ properties:
                   }
 
                   mutate {
-                      remove => [ "msg" ]
+                      remove_field => [ "msg" ]
                   }
               }
           }

--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -2,7 +2,386 @@
 properties:
   <<: (( merge ))
   logstash_parser:
-    filters: "# Parse Cloud Foundry logs from loggregator (syslog)\n# see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156\n\nif [@type] in [\"syslog\", \"relp\"] and [syslog_program] == \"doppler\" {\n# Parse Cloud Foundry logs from doppler (via https://github.com/SpringerPE/firehose-to-syslog)\n\njson {\n    source => 'syslog_message'\n    add_tag => [ 'cloudfoundry_doppler' ] #This is only added if json parsing is successful\n}\n\nif \"_jsonparsefailure\" in [tags] {\n\n    # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard\n    mutate {\n        add_tag => [\"fail/cloudfoundry/doppler/jsonparsefailure_of_syslog_message\"]\n        remove_tag => [\"_jsonparsefailure\"]\n    }\n\n} else {\n\n    date {\n        match => [ \"time\", \"ISO8601\" ]\n    }\n\n    # Replace the unicode newline character \\u2028 with \\n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work\n    mutate {\n      gsub => [ \"msg\", '\\u2028', \"\n\"\n      ]\n    }\n\n    if ('RTR' in [source_type]) {\n        grok {\n            #cf-release > v205 - includes RequestBytesReceived\n            match => { 'msg' => '%{HOSTNAME:hostname} - \\[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\\] \\\"%{WORD:verb} %{URIPATHPARAM:path} %{PROG:http_spec}\\\" %{BASE10NUM:status:int} %{BASE10NUM:request_bytes_received:int} %{BASE10NUM:body_bytes_sent:int} \\\"%{GREEDYDATA:referer}\\\" \\\"%{GREEDYDATA:http_user_agent}\\\" %{HOSTPORT} x_forwarded_for:\\\"%{GREEDYDATA:x_forwarded_for}\\\" vcap_request_id:%{NOTSPACE:vcap_request_id} response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}' }\n\n            #cf-release <= v205\n\t    match => { 'msg' => '%{HOSTNAME:hostname} - \\[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\\] \\\"%{WORD:verb} %{URIPATHPARAM:path} %{PROG:http_spec}\\\" %{BASE10NUM:status:int} %{BASE10NUM:body_bytes_sent:int} \\\"%{GREEDYDATA:referer}\\\" \\\"%{GREEDYDATA:http_user_agent}\\\" %{HOSTPORT} x_forwarded_for:\\\"%{GREEDYDATA:x_forwarded_for}\\\" vcap_request_id:%{NOTSPACE:vcap_request_id} response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}' }\n\t    overwrite => [ \"time\" ]\n\t    tag_on_failure => [ 'fail/cloudfoundry/doppler/RTR' ]\n        }\n\n        if !(\"fail/cloudfoundry/doppler/RTR\" in [tags]) {\n            date {\n                match => [ \"time\", \"dd/MM/y:HH:mm:ss Z\" ]\n            }\n            if [x_forwarded_for] {\n                mutate {\n                    gsub => [\"x_forwarded_for\",\"[\\s\\\\\"]\",\"\"] # remove quotes and whitespace\n                    split => [\"x_forwarded_for\", \",\"] # format is client, proxy1, proxy2 ...\n                }\n\n               mutate {\n                  add_field => [\"remote_addr\", \"%{x_forwarded_for[0]}\"]\n               }\n\n               if ([remote_addr] =~ /([0-9]{1,3}\\.){3}[0-9]{1,3}/) {\n                   geoip {\n                     source => \"remote_addr\"\n                   }\n               }\n            }\n\n            mutate {\n                remove => [ \"msg\" ]\n            }\n        }\n    }\n\n    #Ensure that we always have an event_type, in prep for adding metrics\n    if ![event_type] {\n        mutate {\n            add_field => [ \"event_type\", \"LogMessage\" ]\n        }\n    }\n\n    mutate {\n        remove_field => \"@type\"\n    }\n\n    mutate {\n        add_field => [ \"@type\", \"cloudfoundry_doppler\" ]\n        rename => [ \"syslog_message\", \"@message\" ]\n        remove_field => \"time\"\n        remove_field => \"syslog_severity_code\"\n        remove_field => \"syslog_facility_code\"\n        remove_field => \"syslog_facility\"\n        remove_field => \"syslog_severity\"\n        remove_field => \"syslog_pri\"\n        remove_field => \"syslog_program\"\n        remove_field => \"syslog_pid\"\n    }\n}\n\n} else if [@type] in [\"syslog\", \"relp\"] and [@source.host] == \"loggregator\" {\n# Parse Cloud Foundry logs from loggregator (syslog)\n# see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156\n\nmutate {\n    add_field => [ \"tmp_syslog_procid\" ,\"%{syslog_procid}\" ]\n}\n\n# [App/0] => [App, 0]\nmutate {\n    gsub => [ \"tmp_syslog_procid\", \"[\\[\\]]\", \"\" ]\n    split => [ \"tmp_syslog_procid\", \"/\" ]\n    add_field => [ \"source_type\" ,\"%{[tmp_syslog_procid][0]}\"  ]\n    add_field => [ \"source_instance\" ,\"%{[tmp_syslog_procid][1]}\"  ]\n    remove_field => [ \"tmp_syslog_procid\" ]\n}\n\n# For source types with no instance number, remove the field\nif [source_instance] == \"%{[tmp_syslog_procid][1]}\" {\n    mutate {\n      remove_field => [ \"source_instance\" ]\n    }\n}\n\n#If it looks like JSON, it must be JSON...\nif [syslog_message] =~ /^\\s*{\".*}\\s*$/ {\n    json {\n        source => \"syslog_message\"\n    }\n     # @todo seems like some messages have @timestamp in them? seems ci-specific\n    date {\n        match => [ \"@timestamp\", \"ISO8601\" ]\n    }\n} else {\n    mutate {\n        add_field => [ \"message\", \"%{syslog_message}\" ]\n    }\n    if [message] == \"-\" {\n        mutate {\n            remove_field => \"message\"\n        }\n    }\n}\n mutate {\n    rename => [ \"syslog_program\", \"@source.app_id\" ]\n}\n mutate {\n    add_tag => \"cloudfoundry_loggregator\"\n    remove_field => \"syslog_facility\"\n    remove_field => \"syslog_facility_code\"\n    remove_field => \"syslog_message\"\n    remove_field => \"syslog_severity\"\n    remove_field => \"syslog_severity_code\"\n    remove_field => \"syslog5424_ver\"\n    remove_field => \"syslog6587_msglen\"\n}\n\n} else if [@type] in [\"syslog\", \"relp\"] and [syslog_program] == \"vcap.uaa\" {\n# Parse Cloud Foundry logs from syslog_aggregator\n\ngrok {\n    match => { \"syslog_message\" => \"\\[job=%{NOTSPACE:jobname}%{SPACE}index=%{NOTSPACE:jobindex}\\]%{SPACE}\\[%{TIMESTAMP_ISO8601:uaa_timestamp}\\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\\[%{DATA:thread_name}\\]%{SPACE}....%{SPACE}%{LOGLEVEL:@loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}%{WORD:audit_event_type}%{SPACE}\\('%{DATA:audit_event_data}'\\):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\\[%{DATA:audit_event_origin}\\],%{SPACE}identityZoneId=\\[%{DATA:audit_event_identity_zone_id}\\]\" }\n    tag_on_failure => [\n        \"fail/cloudfoundry/uaa-audit\"\n    ]\n    add_tag => \"uaa-audit\"\n}\n\nif !(\"fail/cloudfoundry/uaa-audit\" in [tags]) {\n    date {\n        match => [ \"uaa_timestamp\", \"ISO8601\" ]\n\tremove_field => \"uaa_timestamp\"\n    }\n\n    if \"PrincipalAuthenticationFailure\" == [audit_event_type] {\n        mutate {\n            add_field => { \"audit_event_remote_address\" => \"%{audit_event_origin}\" }\n       }\n    }\n\n    if [audit_event_origin] =~ /remoteAddress=/ {\n        grok {\n            match => { \"audit_event_origin\" => \"remoteAddress=%{IP:audit_event_remote_address}\" }\n        }\n    }\n\n    if [audit_event_remote_address] {\n       geoip {\n          source => \"audit_event_remote_address\"\n       }\n    }\n\n    mutate {\n        replace => { \"@type\" => \"uaa-audit\" }\n\n\tremove_field => \"syslog_pri\"\n\tremove_field => \"syslog_facility\"\n\tremove_field => \"syslog_facility_code\"\n\tremove_field => \"syslog_message\"\n\tremove_field => \"syslog_severity\"\n\tremove_field => \"syslog_severity_code\"\n\n        rename => { \"syslog_program\" => \"[@source][syslog_program]\" }\n        rename => { \"@source.host\"   => \"[@source][host]\" }\n        rename => { \"jobname\"        => \"[@source][job][name]\" }\n        rename => { \"jobindex\"       => \"[@source][job][index]\" }\n\n        split =>  { \"audit_event_origin\" => \", \" }\n    }\n}\n\n} else if \"collector\" in [tags] {\n# Parse Cloud Foundry Collector\n\nmutate {\n\tremove_field => [ \"level\", \"facility\", \"file\", \"line\", \"version\", \"source_host\" ]\n        rename => { \"attributes\" => \"@source\" }\n\n}\n\nmutate {\n       add_field => { \"[@source][host]\" => \"%{host}\" }\n       add_field => { \"[@source][job_name]\" => \"%{[@source][job]}/%{[@source][index]}\" }\n}\n\nmutate {\n       remove_field => [ \"host\", \"[@source][name]\" ]\n}\n\n} else if [@type] in [\"syslog\", \"relp\"] and [syslog_program] =~ /vcap\\..*/ {\n# Parse Cloud Foundry logs from syslog_aggregator\n\ngrok {\n    match => { \"syslog_message\" => \"(?:\\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\\]|-) %{GREEDYDATA:_message_json}\" }\n    tag_on_failure => [\n        \"_grokparsefailure-cf-vcap\"\n    ]\n}\n\nif !(\"_grokparsefailure-cf-vcap\" in [tags]) {\n    kv {\n        source => \"msgdata\"\n        field_split => \" \"\n        target => \"msgdata\"\n    }\n\n    json {\n        source => \"_message_json\"\n        remove_field => \"_message_json\"\n    }\n\n    mutate {\n        rename => [ \"syslog_program\", \"@shipper.name\" ]\n        replace => [ \"@job.host\", \"%{@source.host}\" ]\n        gsub => [\n            \"@shipper.name\", \"\\.\", \"_\",\n            \"@job.name\", \"\\.\", \"_\"\n          ]\n    }\n\n    if [source] == \"NatsStreamForwarder\" {\n        json {\n            source => \"[data][nats_message]\"\n            target => \"nats_message\"\n        }\n\n        mutate {\n            remove_field => \"[data][nats_message]\"\n        }\n    }\n\n    mutate {\n        add_tag => \"cloudfoundry_vcap\"\n        replace => [ \"@shipper.priority\", \"%{syslog_pri}\" ]\n        replace => [ \"@shipper.name\", \"%{@shipper.name}_%{@type}\" ]\n        replace => [ \"@type\", \"%{@type}_cf\" ]\n    }\n\n    mutate {\n        remove_field => \"syslog_facility\"\n        remove_field => \"syslog_facility_code\"\n        remove_field => \"syslog_message\"\n        remove_field => \"syslog_severity\"\n        remove_field => \"syslog_severity_code\"\n    }\n}\n\n}\n"
+    filters: |
+      # Parse Cloud Foundry logs from loggregator (syslog)
+      # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+
+      if [@type] in ["syslog", "relp"] and [syslog_program] == "doppler" {
+      # Parse Cloud Foundry logs from doppler (via https://github.com/SpringerPE/firehose-to-syslog)
+
+      json {
+          source => 'syslog_message'
+          add_tag => [ 'cloudfoundry_doppler' ] #This is only added if json parsing is successful
+      }
+
+      if "_jsonparsefailure" in [tags] {
+
+          # Amend the failure tag to match our fail/${addon}/${filter}/${detail} standard
+          mutate {
+              add_tag => ["fail/cloudfoundry/doppler/jsonparsefailure_of_syslog_message"]
+              remove_tag => ["_jsonparsefailure"]
+          }
+
+      } else {
+
+          date {
+              match => [ "time", "ISO8601" ]
+          }
+
+          # Replace the unicode newline character \u2028 with \n, which Kibana will display as a new line.  Seems that passing a string with an actual newline in it is the only way to make gsub work
+          mutate {
+            gsub => [ "msg", '\u2028', "
+      "
+            ]
+          }
+
+          if ('RTR' in [source_type]) {
+              grok {
+                  #cf-release > v205 - includes RequestBytesReceived
+                  match => { 'msg' => '%{HOSTNAME:hostname} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:verb} %{URIPATHPARAM:path} %{PROG:http_spec}\" %{BASE10NUM:status:int} %{BASE10NUM:request_bytes_received:int} %{BASE10NUM:body_bytes_sent:int} \"%{GREEDYDATA:referer}\" \"%{GREEDYDATA:http_user_agent}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:x_forwarded_for}\" vcap_request_id:%{NOTSPACE:vcap_request_id} response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}' }
+
+                  #cf-release <= v205
+              match => { 'msg' => '%{HOSTNAME:hostname} - \[(?<time>%{MONTHDAY}/%{MONTHNUM}/%{YEAR}:%{TIME} %{INT})\] \"%{WORD:verb} %{URIPATHPARAM:path} %{PROG:http_spec}\" %{BASE10NUM:status:int} %{BASE10NUM:body_bytes_sent:int} \"%{GREEDYDATA:referer}\" \"%{GREEDYDATA:http_user_agent}\" %{HOSTPORT} x_forwarded_for:\"%{GREEDYDATA:x_forwarded_for}\" vcap_request_id:%{NOTSPACE:vcap_request_id} response_time:%{NUMBER:response_time:float} app_id:%{NOTSPACE}' }
+              overwrite => [ "time" ]
+              tag_on_failure => [ 'fail/cloudfoundry/doppler/RTR' ]
+              }
+
+              if !("fail/cloudfoundry/doppler/RTR" in [tags]) {
+                  date {
+                      match => [ "time", "dd/MM/y:HH:mm:ss Z" ]
+                  }
+                  if [x_forwarded_for] {
+                      mutate {
+                          gsub => ["x_forwarded_for","[\s\\"]",""] # remove quotes and whitespace
+                          split => ["x_forwarded_for", ","] # format is client, proxy1, proxy2 ...
+                      }
+
+                    mutate {
+                        add_field => ["remote_addr", "%{x_forwarded_for[0]}"]
+                    }
+
+                    if ([remote_addr] =~ /([0-9]{1,3}\.){3}[0-9]{1,3}/) {
+                        geoip {
+                          source => "remote_addr"
+                        }
+                    }
+                  }
+
+                  mutate {
+                      remove => [ "msg" ]
+                  }
+              }
+          }
+
+          #Ensure that we always have an event_type, in prep for adding metrics
+          if ![event_type] {
+              mutate {
+                  add_field => [ "event_type", "LogMessage" ]
+              }
+          }
+
+          mutate {
+              remove_field => "@type"
+          }
+
+          mutate {
+              add_field => [ "@type", "cloudfoundry_doppler" ]
+              rename => [ "syslog_message", "@message" ]
+              remove_field => "time"
+              remove_field => "syslog_severity_code"
+              remove_field => "syslog_facility_code"
+              remove_field => "syslog_facility"
+              remove_field => "syslog_severity"
+              remove_field => "syslog_pri"
+              remove_field => "syslog_program"
+              remove_field => "syslog_pid"
+          }
+      }
+
+      } else if [@type] in ["syslog", "relp"] and [@source.host] == "loggregator" {
+      # Parse Cloud Foundry logs from loggregator (syslog)
+      # see https://github.com/cloudfoundry/loggregator/blob/master/src/loggregator/sinks/syslogwriter/syslog_writer.go#L156
+
+      mutate {
+          add_field => [ "tmp_syslog_procid" ,"%{syslog_procid}" ]
+      }
+
+      # [App/0] => [App, 0]
+      mutate {
+          gsub => [ "tmp_syslog_procid", "[\[\]]", "" ]
+          split => [ "tmp_syslog_procid", "/" ]
+          add_field => [ "source_type" ,"%{[tmp_syslog_procid][0]}"  ]
+          add_field => [ "source_instance" ,"%{[tmp_syslog_procid][1]}"  ]
+          remove_field => [ "tmp_syslog_procid" ]
+      }
+
+      # For source types with no instance number, remove the field
+      if [source_instance] == "%{[tmp_syslog_procid][1]}" {
+          mutate {
+            remove_field => [ "source_instance" ]
+          }
+      }
+
+      #If it looks like JSON, it must be JSON...
+      if [syslog_message] =~ /^\s*{".*}\s*$/ {
+          json {
+              source => "syslog_message"
+          }
+          # @todo seems like some messages have @timestamp in them? seems ci-specific
+          date {
+              match => [ "@timestamp", "ISO8601" ]
+          }
+      } else {
+          mutate {
+              add_field => [ "message", "%{syslog_message}" ]
+          }
+          if [message] == "-" {
+              mutate {
+                  remove_field => "message"
+              }
+          }
+      }
+      mutate {
+          rename => [ "syslog_program", "@source.app_id" ]
+      }
+      mutate {
+          add_tag => "cloudfoundry_loggregator"
+          remove_field => "syslog_facility"
+          remove_field => "syslog_facility_code"
+          remove_field => "syslog_message"
+          remove_field => "syslog_severity"
+          remove_field => "syslog_severity_code"
+          remove_field => "syslog5424_ver"
+          remove_field => "syslog6587_msglen"
+      }
+
+      } else if [@type] in ["syslog", "relp"] and [syslog_program] == "vcap.uaa" {
+      # Parse Cloud Foundry logs from syslog_aggregator
+
+      grok {
+          match => { "syslog_message" => "\[job=%{NOTSPACE:jobname}%{SPACE}index=%{NOTSPACE:jobindex}\]%{SPACE}\[%{TIMESTAMP_ISO8601:uaa_timestamp}\]%{SPACE}uaa%{SPACE}-%{SPACE}%{NUMBER:pid:int}%{SPACE}\[%{DATA:thread_name}\]%{SPACE}....%{SPACE}%{LOGLEVEL:@loglevel}%{SPACE}---%{SPACE}Audit:%{SPACE}%{WORD:audit_event_type}%{SPACE}\('%{DATA:audit_event_data}'\):%{SPACE}principal=%{DATA:audit_event_principal},%{SPACE}origin=\[%{DATA:audit_event_origin}\],%{SPACE}identityZoneId=\[%{DATA:audit_event_identity_zone_id}\]" }
+          tag_on_failure => [
+              "fail/cloudfoundry/uaa-audit"
+          ]
+          add_tag => "uaa-audit"
+      }
+
+      if !("fail/cloudfoundry/uaa-audit" in [tags]) {
+          date {
+              match => [ "uaa_timestamp", "ISO8601" ]
+          remove_field => "uaa_timestamp"
+          }
+
+          if "PrincipalAuthenticationFailure" == [audit_event_type] {
+              mutate {
+                  add_field => { "audit_event_remote_address" => "%{audit_event_origin}" }
+            }
+          }
+
+          if [audit_event_origin] =~ /remoteAddress=/ {
+              grok {
+                  match => { "audit_event_origin" => "remoteAddress=%{IP:audit_event_remote_address}" }
+              }
+          }
+
+          if [audit_event_remote_address] {
+            geoip {
+                source => "audit_event_remote_address"
+            }
+          }
+
+          mutate {
+              replace => { "@type" => "uaa-audit" }
+
+          remove_field => "syslog_pri"
+          remove_field => "syslog_facility"
+          remove_field => "syslog_facility_code"
+          remove_field => "syslog_message"
+          remove_field => "syslog_severity"
+          remove_field => "syslog_severity_code"
+
+              rename => { "syslog_program" => "[@source][syslog_program]" }
+              rename => { "@source.host"   => "[@source][host]" }
+              rename => { "jobname"        => "[@source][job][name]" }
+              rename => { "jobindex"       => "[@source][job][index]" }
+
+              split =>  { "audit_event_origin" => ", " }
+          }
+      }
+
+      } else if "collector" in [tags] {
+      # Parse Cloud Foundry Collector
+
+      mutate {
+          remove_field => [ "level", "facility", "file", "line", "version", "source_host" ]
+              rename => { "attributes" => "@source" }
+
+      }
+
+      mutate {
+            add_field => { "[@source][host]" => "%{host}" }
+            add_field => { "[@source][job_name]" => "%{[@source][job]}/%{[@source][index]}" }
+      }
+
+      mutate {
+            remove_field => [ "host", "[@source][name]" ]
+      }
+
+      } else if [@type] in ["syslog", "relp"] and [syslog_program] =~ /vcap\..*/ {
+      # Parse Cloud Foundry logs from syslog_aggregator
+
+      grok {
+          match => { "syslog_message" => "(?:\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\]|-) %{GREEDYDATA:_message_json}" }
+          tag_on_failure => [
+              "_grokparsefailure-cf-vcap"
+          ]
+      }
+
+      if !("_grokparsefailure-cf-vcap" in [tags]) {
+          kv {
+              source => "msgdata"
+              field_split => " "
+              target => "msgdata"
+          }
+
+          json {
+              source => "_message_json"
+              remove_field => "_message_json"
+          }
+
+          mutate {
+              rename => [ "syslog_program", "@shipper.name" ]
+              replace => [ "@job.host", "%{@source.host}" ]
+              gsub => [
+                  "@shipper.name", "\.", "_",
+                  "@job.name", "\.", "_"
+                ]
+          }
+
+          if [source] == "NatsStreamForwarder" {
+              json {
+                  source => "[data][nats_message]"
+                  target => "nats_message"
+              }
+
+              mutate {
+                  remove_field => "[data][nats_message]"
+              }
+          }
+
+          mutate {
+              add_tag => "cloudfoundry_vcap"
+              replace => [ "@shipper.priority", "%{syslog_pri}" ]
+              replace => [ "@shipper.name", "%{@shipper.name}_%{@type}" ]
+              replace => [ "@type", "%{@type}_cf" ]
+          }
+
+          mutate {
+              remove_field => "syslog_facility"
+              remove_field => "syslog_facility_code"
+              remove_field => "syslog_message"
+              remove_field => "syslog_severity"
+              remove_field => "syslog_severity_code"
+          }
+      }
+      }
   elasticsearch_config:
     templates:
-      - logsearch-for-cloudfoundry: "{\n    \"template\" : \"logstash-*\",\n    \"order\" : 50,\n    \"settings\" : {\n\t\"number_of_shards\" : 5,\n\t\"number_of_replicas\" : 1,\n\t\"index\" : {\n            \"search\" : {\n\t\t\"slowlog\" : {\n                    \"threshold\" : {\n\t\t\t\"query\" : {\n                            \"warn\" : \"15s\",\n                            \"info\" : \"10s\",\n                            \"debug\" : \"5s\",\n                            \"trace\" : \"500ms\"\n\t\t\t}\n                    }\n\t\t}\n            },\n            \"query\" : {\n\t\t\"default_field\" : \"@message\"\n            },\n            \"store\" : {\n\t\t\"compress\" : {\n                    \"stored\" : true,\n                    \"tv\": true\n\t\t}\n            }\n\t}\n    },\n    \"mappings\": {\n\t\"_default_\": {\n            \"_all\": {\n\t\t\"enabled\": false\n            },\n            \"_source\": {\n\t\t\"compress\": true\n            },\n            \"dynamic_templates\": [\n\t\t{\n                    \"string_template\" : {\n\t\t\t\"match\" : \"*\",\n\t\t\t\"mapping\": {\n                            \"type\": \"string\",\n                            \"index\": \"not_analyzed\",\n                            \"norms\" : {\n\t\t\t\t\"enabled\" : false\n                            }\n\t\t\t},\n\t\t\t\"match_mapping_type\" : \"string\"\n                    }\n\t\t}\n            ],\n            \"properties\" : {\n\t\t\"@message\" : {\n                    \"type\" : \"string\",\n                    \"index\" : \"analyzed\",\n                    \"norms\" : {\n\t\t\t\"enabled\" : false\n                    }\n\t\t},\n\t\t\"@tags\": {\n                    \"type\": \"string\",\n                    \"index\" : \"not_analyzed\",\n                    \"norms\" : {\n\t\t\t\"enabled\" : false\n                    }\n\t\t},\n\t\t\"@timestamp\" : {\n                    \"type\" : \"date\",\n                    \"index\" : \"not_analyzed\"\n\t\t},\n\t\t\"@type\" : {\n                    \"type\" : \"string\",\n                    \"index\" : \"not_analyzed\",\n                    \"norms\" : {\n\t\t\t\"enabled\" : false\n                    }\n\t\t},\n\t\t\"message\" : {\n                    \"type\" : \"string\",\n                    \"index\" : \"analyzed\",\n                    \"norms\" : {\n\t\t\t\"enabled\" : false\n                    }\n\t\t},\n\t\t\"geoip\" : {\n                    \"properties\" : {\n\t\t\t\"location\" : {\n\t\t\t    \"type\" : \"geo_point\"\n\t\t\t}\n\t\t    }\n\t\t}\n            }\n\t}\n    }\n}\n\n" 
+      - logsearch-for-cloudfoundry: |
+          {
+              "template" : "logstash-*",
+              "order" : 50,
+              "settings" : {
+              "number_of_shards" : 5,
+              "number_of_replicas" : 1,
+              "index" : {
+                      "search" : {
+                  "slowlog" : {
+                              "threshold" : {
+                      "query" : {
+                                      "warn" : "15s",
+                                      "info" : "10s",
+                                      "debug" : "5s",
+                                      "trace" : "500ms"
+                      }
+                              }
+                  }
+                      },
+                      "query" : {
+                  "default_field" : "@message"
+                      },
+                      "store" : {
+                  "compress" : {
+                              "stored" : true,
+                              "tv": true
+                  }
+                      }
+              }
+              },
+              "mappings": {
+              "_default_": {
+                      "_all": {
+                  "enabled": false
+                      },
+                      "_source": {
+                  "compress": true
+                      },
+                      "dynamic_templates": [
+                  {
+                              "string_template" : {
+                      "match" : "*",
+                      "mapping": {
+                                      "type": "string",
+                                      "index": "not_analyzed",
+                                      "norms" : {
+                          "enabled" : false
+                                      }
+                      },
+                      "match_mapping_type" : "string"
+                              }
+                  }
+                      ],
+                      "properties" : {
+                  "@message" : {
+                              "type" : "string",
+                              "index" : "analyzed",
+                              "norms" : {
+                      "enabled" : false
+                              }
+                  },
+                  "@tags": {
+                              "type": "string",
+                              "index" : "not_analyzed",
+                              "norms" : {
+                      "enabled" : false
+                              }
+                  },
+                  "@timestamp" : {
+                              "type" : "date",
+                              "index" : "not_analyzed"
+                  },
+                  "@type" : {
+                              "type" : "string",
+                              "index" : "not_analyzed",
+                              "norms" : {
+                      "enabled" : false
+                              }
+                  },
+                  "message" : {
+                              "type" : "string",
+                              "index" : "analyzed",
+                              "norms" : {
+                      "enabled" : false
+                              }
+                  },
+                  "geoip" : {
+                              "properties" : {
+                      "location" : {
+                          "type" : "geo_point"
+                      }
+                      }
+                  }
+                      }
+              }
+              }
+          }

--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -1,4 +1,3 @@
-
 properties:
   <<: (( merge ))
   logstash_parser:
@@ -285,6 +284,15 @@ properties:
           }
       }
       }
+      # Short term fix (aka definitive solution), drop the data field to avoid
+      # error inserting in ES.
+      # If not, we get the error: failed action with response of 400
+      if [@shipper.name] == "vcap_routing-api_relp" {
+        mutate {
+          remove_field => [ "data" ]
+        }
+      }
+
   elasticsearch_config:
     templates:
       - logsearch-for-cloudfoundry: |
@@ -385,3 +393,4 @@ properties:
               }
               }
           }
+

--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -243,9 +243,16 @@ properties:
               target => "msgdata"
           }
 
-          json {
-              source => "_message_json"
-              remove_field => "_message_json"
+          #If it looks like JSON, it must be JSON...
+          if [_message_json] =~ /^\s*{".*}\s*$/ {
+              json {
+                  source => "_message_json"
+                  remove_field => "_message_json"
+              }
+          } else {
+              mutate {
+                  rename => [ "_message_json", "_message_invalid_json" ]
+              }
           }
 
           mutate {
@@ -258,13 +265,19 @@ properties:
           }
 
           if [source] == "NatsStreamForwarder" {
-              json {
-                  source => "[data][nats_message]"
-                  target => "nats_message"
-              }
-
-              mutate {
-                  remove_field => "[data][nats_message]"
+              #If it looks like JSON, it must be JSON...
+              if [data][nats_message] =~ /^\s*{".*}\s*$/ {
+                  json {
+                      source => "[data][nats_message]"
+                      target => "nats_message"
+                  }
+                  mutate {
+                      remove_field => "[data][nats_message]"
+                  }
+              } else {
+                  mutate {
+                      rename => [ "[data][nats_message]", "_nats_invalid_json" ]
+                  }
               }
           }
 

--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -230,7 +230,7 @@ properties:
       # Parse Cloud Foundry logs from syslog_aggregator
 
       grok {
-          match => { "syslog_message" => "(?:\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\]|-) %{GREEDYDATA:_message_json}" }
+          match => { "syslog_message" => "(?:\[job=%{NOTSPACE:@job.name}|-) +(?:index=%{NOTSPACE:@job.index}\]|-) +%{GREEDYDATA:_message_json} *" }
           tag_on_failure => [
               "_grokparsefailure-cf-vcap"
           ]


### PR DESCRIPTION
See: [#107588012 BUG: Logsearch is creating a log entry for every parsed line](https://www.pivotaltracker.com/story/show/107588012)
# What

We are getting several errors in logstash output while parsing cloufoundry messages:

```
{:timestamp=>"2015-11-02T10:57:40.698000+0000", :message=>"You are using a deprecated config setting \"index_type\" set in elasticsearch. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future. Please use the 'document_type' setting instead. It has the same effect, but is more appropriately named. If you have any questions about this, please visit the #logstash channel on freenode irc.", :name=>"index_type", :plugin=><LogStash::Outputs::ElasticSearch host=>"127.0.0.1:9200", protocol=>"http", flush_size=>100, index=>"logstash-%{+YYYY.MM.dd}", index_type=>"%{@type}", manage_template=>"false">, :level=>:warn}
{:timestamp=>"2015-11-02T10:57:40.868000+0000", :message=>"You are using a deprecated config setting \"remove\" set in mutate. Deprecated settings will continue to work, but are scheduled for removal from logstash in the future.  If you have any questions about this, please visit the #logstash channel on freenode irc.", :name=>"remove", :plugin=><LogStash::Filters::Mutate remove=>["msg"]>, :level=>:warn}
{:timestamp=>"2015-11-04T12:12:06.259000+0000", :message=>"Trouble parsing json", :source=>"_message_json", :raw=>" rsyslog start/running, process 17342", :exception=>#<LogStash::Json::ParserError: Unrecognized token 'rsyslog': was expecting ('true', 'false' or 'null')
 at [Source: [B@78d9dcde; line: 1, column: 10]>, :level=>:warn}
{:timestamp=>"2015-11-04T12:12:08.173000+0000", :message=>"Trouble parsing json", :source=>"_message_json", :raw=>" PostgreSQL started successfully", :exception=>#<LogStash::Json::ParserError: Unrecognized token 'PostgreSQL': was expecting ('true', 'false' or 'null')
 at [Source: [B@64d8ea19; line: 1, column: 13]>, :level=>:warn}
{:timestamp=>"2015-11-04T12:12:08.169000+0000", :message=>"Trouble parsing json", :source=>"_message_json", :raw=>" waiting for server to start.... done", :exception=>#<LogStash::Json::ParserError: Unrecognized token 'waiting': was expecting ('true', 'false' or 'null')
 at [Source: [B@51ff03b1; line: 1, column: 10]>, :level=>:warn}
{:timestamp=>"2015-11-04T12:12:08.197000+0000", :message=>"Trouble parsing json", :source=>"_message_json", :raw=>" CREATE ROLE", :exception=>#<LogStash::Json::ParserError: Unrecognized token 'CREATE': was expecting ('true', 'false' or 'null')
 at [Source: [B@49f0fd90; line: 1, column: 9]>, :level=>:warn}
{:timestamp=>"2015-11-12T14:06:53.252000+0000", :message=>"failed action with response of 400, dropping action: [\"index\", {:_id=>nil, :_index=>\"logstash-2015.11.12\", :_type=>\"relp_cf\", :_routing=>nil},
```

They end filling the disk fast, we need to get rid of them.
# Context

This PR should be reviewed in this scope
- We make our filter configuration in the manifest more human friendly using yaml multiline (not a huge line)
- We fix several json parsing errors by trimming json and ensure that the json looks like json before parsing.
- We drop some fields that failed being inserted in ElasticSearch by an undetermined instance (we won't spend more time troubleshooting that, as the message is not so important).
# How to test this:
1. Deploy the logsearch deployment with a CF deployment
2. SSH to the logsearch VM: `bosh ssh logsearch_minimal`
3. Check that the parser log does not display the errors described above (in startup it can report some deprecated config warnings about `index_type`, not related to this PR): `tail -f /var/vcap/sys/log/parser/parser.stdout.log`
# Who can review this?

Anyone but @jimconner or @keymon
