### PR TITLE
[#107185624] Free service-plan for psql broker

### DIFF
--- a/scripts/deploy_psql_broker.sh
+++ b/scripts/deploy_psql_broker.sh
@@ -53,4 +53,7 @@ cf service-brokers | grep -q ${URL}
 if [[ ! $? == 0 ]] ; then
   cf create-service-broker postgresql-cf-service-broker user ${PSQL_ADMIN_PASS} https://${URL}
   cf enable-service-access PostgreSQL -p "Basic PostgreSQL Plan"
+  # Set the service plan to be free of charge.
+  PSQL_PLAN_GUID=`cf curl /v2/service_plans -X 'GET' | jq -r '(.resources[] | select(.entity.name == "Basic PostgreSQL Plan")).metadata.guid'`
+  cf curl /v2/service_plans/$PSQL_PLAN_GUID -X 'PUT' -d '{"free":true}'
 fi

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -86,6 +86,7 @@ install_dependencies() {
     dstat
     unzip
     bundler
+    jq
   "
 
   echo "Installing system packages..."


### PR DESCRIPTION
[#107185624 Remove the cost for Postgres on CF](https://www.pivotaltracker.com/story/show/107185624)
# What

When creating a postgres server there is the following advisory message:

```
$ cf create-service PostgreSQL "Basic PostgreSQL Plan" my_flaskapp_db
Attention: The plan `Basic PostgreSQL Plan` of service `Postgresql` is not free. The instance `my_spring_db` will incur a cost. Contact your administrator if you think this is in error.
```

We should try to remove this.
# Context

For the time being, and instead of forking the upstream broker, we will change the setting of the service broker using `cf curl /v2/service_plans/$PSQL_PLAN_GUID -X 'PUT' -d '{"free":true}'` after adding the broker. For that we need to query the API to get the PSQL_PLAN_GUID.

Specifically:
- Add jq package to bastion for parsing json
- Use `cf curl` to fetch service plans and parse the json to get the plan GUID
- use `cf curl` to set the 'free' parameter to 'true'
# How to test this

You will need a fresh environment (`make aws DEPLOY_ENV=...`) or, optionally delete the postgres broker and run the deploy scripts again (`make aws DEPLOY_ENV=...`).
## To remove the broker:

``` bash
# login in CF
cf login --skip-ssl-validation -a  https://api.$DEPLOY_ENV.cf.paas.alphagov.co.uk -u admin -p $(paas-pass cloudfoundry/cf_admin_password)
# remove the broker
cf  delete-service-broker "postgresql-cf-service-broker" -f
# remove the app
cf delete postgresql-cf-service-broker -f 
```
## Deploy Flask-sqlalchemy on CloudFoundry to test the postgresql service instance

``` bash
$ git clone https://github.com/alphagov/flask-sqlalchemy-postgres-heroku-example.git
$ cd flask-sqlalchemy-postgres-heroku-example
$ cf push flask_app --no-start
```

The Flask-sqlalchemy application requires a backend data service to run, so you will need to create a service instance of postgresql and bind it to the application as follows.

``` bash
$ cf marketplace # view the services available
$ cf create-service Postgresql "Basic PostgreSQL Plan" my_flaskapp_db
$ cf bind-service flask_app my_flaskapp_db
$ cf restart flask_app # restart the app to detect the new db service
```

The `cf apps` command will list the URLs associated with the app.
# Who can review this?

Anyone but @keymon or @jimconner 
