### PR TITLE
Add terraform output for grafana dns name on GCE and adjust grafana firewall

### DIFF
--- a/gce/firewall.tf
+++ b/gce/firewall.tf
@@ -78,7 +78,10 @@ resource "google_compute_firewall" "graphite" {
 
   source_ranges = [ "${split(",", var.office_cidrs)}",
                     "${var.bastion_cidr}",
-                    "${var.jenkins_elastic}" ]
+                    "${var.jenkins_elastic}",
+                    "${google_compute_address.bosh.address}/32",
+                    "${google_compute_instance.bastion.network_interface.0.access_config.0.nat_ip}/32",
+                    "${google_compute_instance.bastion.network_interface.0.address}/32" ]
   target_tags = [ "graphite1" ]
 
   allow {

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -54,6 +54,10 @@ output "cf_root_domain" {
 	value = "${var.env}.${var.dns_zone_name}"
 }
 
+output "grafana_dns_name" {
+  value = "${google_dns_record_set.grafana.name}"
+}
+
 output "dns_zone_name" {
 	value = "${var.dns_zone_name}"
 }

--- a/gce/outputs.tf
+++ b/gce/outputs.tf
@@ -55,7 +55,7 @@ output "cf_root_domain" {
 }
 
 output "grafana_dns_name" {
-  value = "${google_dns_record_set.grafana.name}"
+  value = "${replace(google_dns_record_set.grafana.name, "/\.$/", "")}"
 }
 
 output "dns_zone_name" {


### PR DESCRIPTION
# What

On #66 we added a dependency on the output of terraform to get the grafana url. But this output was not added in GCE.

Additionally, the bastion host needs to access grafana endpoint to setup the dashboards.
# Scope

Add a new output `grafana_dns_name` to gce terraform and open the firewall to allow access from the bastion host.
# how to test

GCE deployment should work. 

You can see it by running  [the jenkins job](https://deploy.tools.paas.alphagov.co.uk/job/ci-cf-deploy-daily-build-gce/) using this branch.
# Who can review this

anyone but me
