### PR TITLE
[#107994314] Use newly split out dev/trial SSL certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ aws/.terraform
 *smoke_test*.json
 manifests/templates/outputs/terraform-outputs-*.yml
 scripts/terraform-outputs-*.sh
+manifests/templates/cf-secrets.yml
+manifests/templates/cf-ssl-certificates.yml

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ ROOT_PASS_DIR ?= .
 all:
 	$(error Usage: make <aws|gce> DEPLOY_ENV=name)
 
+ifeq "$(DEPLOY_ENV)" "trial"
+    SSL_CERTIFICATES_FILE := cloudfoundry/cf-trial-ssl-certificates.yml
+else
+    SSL_CERTIFICATES_FILE := cloudfoundry/cf-dev-ssl-certificates.yml
+endif
+
 check-env-vars:
 ifndef DEPLOY_ENV
     $(error Must pass DEPLOY_ENV=<name>)
@@ -19,8 +25,7 @@ set-gce:
 bastion:
 	$(eval bastion=$(shell DEPLOY_ENV=${DEPLOY_ENV} ./scripts/get_bastion_host.sh ${dir}))
 
-aws: set-aws apply prepare-provision-aws prepare-dev-ssl provision deploy-cf deploy-logsearch deploy-redis
-aws-trial: set-aws apply prepare-provision-aws prepare-trial-ssl provision deploy-cf deploy-logsearch deploy-redis
+aws: set-aws apply prepare-provision-aws provision deploy-cf deploy-logsearch deploy-redis
 gce: set-gce apply prepare-provision-gce provision deploy-cf deploy-logsearch deploy-redis
 
 apply-aws: set-aws apply
@@ -52,14 +57,7 @@ prepare-provision: bastion
 	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-secrets.yml'
 	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/bosh-secrets.yml | \
 	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/bosh-secrets.yml'
-
-prepare-dev-ssl: bastion
-	scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
-	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf-dev-ssl-certificates.yml | \
-	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-ssl-certificates.yml'
-prepare-trial-ssl: bastion
-	scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
-	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf-trial-ssl-certificates.yml | \
+	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/${SSL_CERTIFICATES_FILE} | \
 	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-ssl-certificates.yml'
 
 test-aws: set-aws test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ set-gce:
 bastion:
 	$(eval bastion=$(shell DEPLOY_ENV=${DEPLOY_ENV} ./scripts/get_bastion_host.sh ${dir}))
 
-aws: set-aws apply prepare-provision-aws provision deploy-cf deploy-logsearch deploy-redis
+aws: set-aws apply prepare-provision-aws prepare-dev-ssl provision deploy-cf deploy-logsearch deploy-redis
+aws-trial: set-aws apply prepare-provision-aws prepare-trial-ssl provision deploy-cf deploy-logsearch deploy-redis
 gce: set-gce apply prepare-provision-gce provision deploy-cf deploy-logsearch deploy-redis
 
 apply-aws: set-aws apply
@@ -51,6 +52,15 @@ prepare-provision: bastion
 	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-secrets.yml'
 	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/bosh-secrets.yml | \
 	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/bosh-secrets.yml'
+
+prepare-dev-ssl: bastion
+	scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
+	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf-dev-ssl-certificates.yml | \
+	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-ssl-certificates.yml'
+prepare-trial-ssl: bastion
+	scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
+	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf-trial-ssl-certificates.yml | \
+	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-ssl-certificates.yml'
 
 test-aws: set-aws test
 test-gce: set-gce test

--- a/manifests/generate_deployment_manifest.sh
+++ b/manifests/generate_deployment_manifest.sh
@@ -36,4 +36,5 @@ spiff merge \
   $templates/${infrastructure}/stubs/*.yml \
   $templates/outputs/terraform-outputs-${infrastructure}.yml \
   $templates/cf-secrets.yml \
+  $templates/cf-ssl-certificates.yml \
   "$@"


### PR DESCRIPTION
# What

This adds a new trial SSL certificates that have been added to paas-pass. 
We pick the certificates from paas-pass based on the deployment name.

On deployment the new secrets files are decrypted, uploaded to the bastion, 
and then merged into the manifest at generation time.

The paas-pass changes _must_ be merged at the same time as this PR: https://github.gds/multicloudpaas/credentials/pull/27
## How to test this PR

Checkout the new multicloudpaas branch to your `.paas-pass` directory, checkout this cf-terraform branch, and then...

`make aws DEPLOY_ENV=ssltest`

Hit https://api.ssltest.cf.paas.alphagov.co.uk in chrome, expand the advanced panel and you should see:

```
This server could not prove that it is api.ssltest.cf.paas.alphagov.co.uk; its security certificate is not trusted by your computer's operating system. This may be caused by a misconfiguration or an attacker intercepting your connection.
```

Then...

`make aws DEPLOY_ENV=ssltest`

Hit https://api.ssltest.cf.paas.alphagov.co.uk in chrome, expand the advanced panel and you should see:

```
This server could not prove that it is api.ssltest.cf.paas.alphagov.co.uk; its security certificate is from *.trial.cf.paas.alphagov.co.uk. This may be caused by a misconfiguration or an attacker intercepting your connection.
```

Note that the text above is _subtly different_ from before - you're looking for the string `*.trial.cf.paas.alphagov.co.uk.` to indicate that all is good and wonderful.
## Who can test this PR

Anybody but @actionjack or @jonty. I think @keymon was excited by it.
