### PR TITLE
[#108062984] Open the trial environment to IP addresses beyond AH

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export TF_VAR_GCE_INTEROPERABILITY_HOST=s3-eu-west-1.amazonaws.com
 ### Build
 ```
 make gce DEPLOY_ENV=<environment_name> # or...
-make aws DEPLOY_ENV=<environment_name>
+make aws DEPLOY_ENV=<environment_name> [WEB_ACCESS_CIDRS='<comma separated list of cidrs>']
 ```
 
 This actually includes 3 separate stages:
@@ -51,6 +51,8 @@ This actually includes 3 separate stages:
 1. Terraform
 2. Provision BOSH
 3. Deploy Cloud Foundry
+
+The optional argument WEB_ACCESS_CIDRS can be used to overide the default web access ingress range. It accepts a comma separated list of cidrs (no spaces)
 
 ### Destroy
 

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -153,7 +153,7 @@ resource "aws_security_group" "web" {
     to_port   = 80
     protocol  = "tcp"
     cidr_blocks = [
-      "${split(",", var.office_cidrs)}",
+      "${split(",", var.web_access_cidrs)}",
       "${aws_instance.bastion.public_ip}/32",
       "${var.jenkins_elastic}"
     ]
@@ -167,7 +167,7 @@ resource "aws_security_group" "web" {
     to_port   = 443
     protocol  = "tcp"
     cidr_blocks = [
-      "${split(",", var.office_cidrs)}",
+      "${split(",", var.web_access_cidrs)}",
       "${aws_instance.bastion.public_ip}/32",
       "${var.jenkins_elastic}"
     ]
@@ -181,7 +181,7 @@ resource "aws_security_group" "web" {
     to_port   = 4443
     protocol  = "tcp"
     cidr_blocks = [
-      "${split(",", var.office_cidrs)}",
+      "${split(",", var.web_access_cidrs)}",
       "${aws_instance.bastion.public_ip}/32",
       "${var.jenkins_elastic}"
     ]

--- a/globals.tf
+++ b/globals.tf
@@ -7,6 +7,11 @@ variable "office_cidrs" {
   default     = "80.194.77.90/32,80.194.77.100/32"
 }
 
+variable "web_access_cidrs" {
+  description = "CSV of CIDR addresses for which we allow web access"
+  default     = "80.194.77.90/32,80.194.77.100/32"
+}
+
 variable "ssh_user" {
   description = "Username used to ssh into VMs."
   default     = "ubuntu"


### PR DESCRIPTION
**What**

We want to (optionally) open up web access to deployed apps in the trial environment so they are available from anywhere and not just aviation house ips.

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I want to be able to specify an alternative cidr range for web access
- I want to retain the existing office cidr range for all other access

**How to test this PR**
- Provision an environment setting the `WEB_ACCESS_CIDRS` variable
- This should cleanly deploy to existing environments
- e.g `make aws DEPLOY_ENV=<env> WEB_ACCESS_CIDRS='0.0.0.0/0'`
- Confirm results by examining security groups in aws console
- Deploy an app and confirm it can be accessed from the specified CIDR

**Who should review this PR**
- Anyone in the core team except @jimconner who I paired with
