### PR TITLE
[#107025876] Automatically update paas-pass in jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ ifdef WEB_ACCESS_CIDRS
     WEB_ACCESS_OPTION= -var web_access_cidrs=${WEB_ACCESS_CIDRS}
 endif
 
-set-aws:
+set-aws: update-paas-pass
 	$(eval dir=aws)
-set-gce:
+set-gce: update-paas-pass
 	$(eval dir=gce)
 	$(eval apply_suffix=-var gce_account_json="`tr -d '\n' < account.json`")
 bastion:
@@ -139,3 +139,6 @@ ssh-aws: set-aws ssh
 ssh-gce: set-gce ssh
 ssh: check-env-vars bastion
 	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} ${CMD}
+
+update-paas-pass:
+	PASSWORD_STORE_DIR=~/.paas-pass pass git pull --rebase


### PR DESCRIPTION
# What

Story: https://www.pivotaltracker.com/story/show/107025876

We want to use up-to-date passwords whenever we do actions that requires them
- this creates an `update-paas-pass` make command
- it is called in `set-aws` that is called everytime
- it doesn't assume that you must use paas-pass `master` branch so you can use another one, it will be updated as well
# How to review
- `make aws DEPLOY_ENV=xxxx` should update paas-pass
# Who can review

Anyone but @saliceti or @keymon 
