### PR TITLE
[#108231570] Upgrade the bastion instance to increase bandwidth

### DIFF
--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -1,6 +1,6 @@
 resource "aws_instance" "bastion" {
   ami = "${lookup(var.ubuntu_amis, var.region)}"
-  instance_type = "t2.micro"
+  instance_type = "m3.medium"
   subnet_id = "${aws_subnet.infra.0.id}"
   private_ip = "10.0.0.4"
   associate_public_ip_address = true


### PR DESCRIPTION
Due to the bastion host also acting as the NAT box for our environments
it's under a lot more load than expected, resulting in the amount of
available credits slowly dropping. Upgrading to an m3.medium with
"medium" network performance rather than low.
