### PR TITLE
Working implementation of Dockerised BOSH tools

### DIFF
--- a/containers/tools/Dockerfile
+++ b/containers/tools/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:14.04
+
+RUN locale-gen en_US.UTF-8
+RUN dpkg-reconfigure locales
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+ADD Gemfile /tmp/Gemfile
+ADD Gemfile.lock /tmp/Gemfile.lock
+ADD install_dependencies.sh /tmp/install_dependencies.sh
+RUN chmod a+x /tmp/install_dependencies.sh
+RUN /tmp/install_dependencies.sh
+
+RUN apt-get clean

--- a/containers/tools/Gemfile
+++ b/containers/tools/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem 'bosh_cli', '~> 1.3056.0'
+gem 'net-ssh', '~> 2.9.2'
+

--- a/containers/tools/Gemfile.lock
+++ b/containers/tools/Gemfile.lock
@@ -1,0 +1,172 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.1)
+    aws-sdk (1.60.2)
+      aws-sdk-v1 (= 1.60.2)
+    aws-sdk-v1 (1.60.2)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+    blobstore_client (1.3056.0)
+      aws-sdk (= 1.60.2)
+      bosh_common (~> 1.3056.0)
+      fog (~> 1.31.0)
+      fog-aws (<= 0.1.1)
+      httpclient (= 2.4.0)
+      multi_json (~> 1.1)
+    bosh-template (1.3056.0)
+      semi_semantic (~> 1.1.0)
+    bosh_cli (1.3056.0)
+      blobstore_client (~> 1.3056.0)
+      bosh-template (~> 1.3056.0)
+      bosh_common (~> 1.3056.0)
+      cf-uaa-lib (~> 3.2.1)
+      highline (~> 1.6.2)
+      httpclient (= 2.4.0)
+      json_pure (~> 1.7)
+      minitar (~> 0.5.4)
+      net-scp (~> 1.1.0)
+      net-ssh (>= 2.2.1)
+      net-ssh-gateway (~> 1.2.0)
+      netaddr (~> 1.5.0)
+      progressbar (~> 0.9.0)
+      terminal-table (~> 1.4.3)
+    bosh_common (1.3056.0)
+      logging (~> 1.8.2)
+      semi_semantic (~> 1.1.0)
+    builder (3.2.2)
+    cf-uaa-lib (3.2.4)
+      multi_json
+    excon (0.45.4)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.31.0)
+      fog-atmos
+      fog-aws (~> 0.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.30)
+      fog-ecloud
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.9.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.32.1)
+      builder
+      excon (~> 0.45)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.0.9)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.5)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.3.2)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.7)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    highline (1.6.21)
+    httpclient (2.4.0)
+    inflecto (0.0.2)
+    ipaddress (0.8.0)
+    json (1.8.3)
+    json_pure (1.8.2)
+    little-plugger (1.1.4)
+    logging (1.8.2)
+      little-plugger (>= 1.1.3)
+      multi_json (>= 1.8.4)
+    mime-types (2.6.2)
+    mini_portile (0.6.2)
+    minitar (0.5.4)
+    multi_json (1.11.2)
+    net-scp (1.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    net-ssh-gateway (1.2.0)
+      net-ssh (>= 2.6.5)
+    netaddr (1.5.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    progressbar (0.9.2)
+    semi_semantic (1.1.0)
+    terminal-table (1.4.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bosh_cli (~> 1.3056.0)
+  net-ssh (~> 2.9.2)
+
+BUNDLED WITH
+   1.10.6

--- a/containers/tools/install_dependencies.sh
+++ b/containers/tools/install_dependencies.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+PACKAGES="
+  openssh-client
+  build-essential
+  git
+  golang
+  zlibc
+  zlib1g-dev
+  ruby
+  ruby-dev
+  openssl
+  libxslt1-dev
+  libxml2-dev
+  libssl-dev
+  libreadline6
+  libreadline6-dev
+  libyaml-dev
+  libsqlite3-dev
+  sqlite3
+  dstat
+  unzip
+  bundler
+  jq
+  wget
+"
+
+# For go 1.5
+apt-get install -y --no-install-recommends software-properties-common
+add-apt-repository -y ppa:ubuntu-lxc/lxd-stable
+
+apt-get update
+apt-get -y upgrade
+apt-get install -y --no-install-recommends $PACKAGES
+
+BOSH_INIT_VERSION=0.0.72
+BOSH_INIT_URL=https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-${BOSH_INIT_VERSION}-linux-amd64
+SPIFF_VERSION=v1.0.7
+SPIFF_URL=https://github.com/cloudfoundry-incubator/spiff/releases/download/${SPIFF_VERSION}/spiff_linux_amd64.zip
+CF_CLI_VERSION=6.12.3
+
+export BUNDLE_GEMFILE=/tmp/Gemfile
+echo "Installing gem packages..."
+bundle install
+
+echo "Installing binaries: bosh-init, spiff, cf..."
+wget -q $BOSH_INIT_URL -O /usr/local/bin/bosh-init
+chmod +x /usr/local/bin/bosh-init
+
+wget -q $SPIFF_URL -O spiff_linux_amd64.zip
+unzip -qo spiff_linux_amd64.zip -d /usr/local/bin
+chmod +x /usr/local/bin/spiff
+rm spiff_linux_amd64.zip
+
+wget -q -O /tmp/cf-cli_${CF_CLI_VERSION}_amd64.deb "https://cli.run.pivotal.io/stable?release=debian64&version=${CF_CLI_VERSION}&source=github-rel"
+dpkg -i /tmp/cf-cli_${CF_CLI_VERSION}_amd64.deb > /dev/null
+rm /tmp/cf-cli_${CF_CLI_VERSION}_amd64.deb


### PR DESCRIPTION
Running "docker build ." will generate a container that has bosh and all
it's dependencies in it, along with other tools that we require for
provisioning. You can bosh-init from within the container, along with
all other bastion tasks.

To use the container you'll want to mount a directory containing all the
files required by bosh when provisioning that are outputted from the
Make process, e.g.:

```
  docker run -ti -w /root/ --rm=true -v /Users/jonty/gds/cf-terraform/:/root/ 130f2b52822c /home/root/scripts/provision.sh aws
```

The current provision script will fail when running directly from
cf-terraform as the directory structure that we currently create on the
bastion is slightly different. If we wish to adopt this approach fully
then we need to refactor our layout and provisioning scripts to be
identical, and ideally the makefile should be able to output the spiffed
manifest layout locally without copying to the bastion.

We also copy over the Gemfile (and .lock) to this directory as docker
will not allow you to add files outside the current working directory,
and does not follow symlinks. We should change the repository layout to
ensure we only have one copy of these files.
