### PR TITLE
[#108623798] Move logging endpoints to port 443

### DIFF
--- a/aws/routers.tf
+++ b/aws/routers.tf
@@ -26,11 +26,5 @@ resource "aws_elb" "router" {
     lb_port = 443
     lb_protocol = "tcp"
   }
-  listener {
-    instance_port = 443
-    instance_protocol = "tcp"
-    lb_port = 4443
-    lb_protocol = "tcp"
-  }
 }
 

--- a/aws/security-groups.tf
+++ b/aws/security-groups.tf
@@ -176,20 +176,6 @@ resource "aws_security_group" "web" {
     ]
   }
 
-  ingress {
-    from_port = 4443
-    to_port   = 4443
-    protocol  = "tcp"
-    cidr_blocks = [
-      "${split(",", var.web_access_cidrs)}",
-      "${aws_instance.bastion.public_ip}/32",
-      "${var.jenkins_elastic}"
-    ]
-    security_groups = [
-      "${aws_security_group.bosh_vm.id}"
-    ]
-  }
-
   tags {
     Name = "${var.env}-cf-web"
   }

--- a/manifests/templates/aws/stubs/cf-stub-aws.yml
+++ b/manifests/templates/aws/stubs/cf-stub-aws.yml
@@ -44,6 +44,10 @@ resource_pools:
       - (( terraform_outputs.elb_name ))
 
 properties:
+  doppler:
+    port: 443
+  logger_endpoint:
+    port: 443
   graphite:
     server: 10.0.10.40
   domain: (( terraform_outputs.environment ".cf.paas.alphagov.co.uk" ))


### PR DESCRIPTION
**What**

The default logging websocket endpoint of 4443 is blocked by many organizations firewalls, which makes things difficult for them when using our platform. The default of 4443 was required on GCE (where the load balancer did not support certificates), but is not necessary on AWS, so we're reconfiguring to use 443 instead for a better user experience.

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I need to be able to access app logs on port 443.

**How to test this PR**
- Deploy to AWS as normal using the Makefile
- Drink coffee<sup>*</sup> until the deployment is complete. 
- Confirm that that pushing apps still works correctly and that app logs are still available.
- Confirm removal of port 4443 from security groups and ELB listeners by manual inspection
- All done.

<sup>*or an alternative beverage of your choice</sup>

**Who should review this PR**

Anyone on the core team apart from @mtekel or @jimconner as they both worked on this story.
