### PR TITLE
[#108745950] Use SSD for graphite's persistent disk.

### DIFF
--- a/manifests/templates/aws/stubs/graphite-stub.yml
+++ b/manifests/templates/aws/stubs/graphite-stub.yml
@@ -4,6 +4,12 @@ meta:
     z1: (( terraform_outputs.zone0 ))
     z2: (( terraform_outputs.zone1 ))
 
+disk_pools:
+  - name: graphite_data
+    disk_size: 204800
+    cloud_properties: {type: gp2}
+
+
 resource_pools:
   - name: graphite_z1
     cloud_properties:
@@ -18,7 +24,7 @@ resource_pools:
 jobs:
   - name: graphite
     instances: 1
-    persistent_disk: 204800
+    persistent_disk_pool: graphite_data
     networks:
     - name: cf1
       static_ips: [ 10.0.10.40 ]

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -43,7 +43,7 @@ jobs:
   - name: cf1
     static_ips: ~
   networks: (( merge || default_networks ))
-  persistent_disk: (( merge || 2048 ))
+  persistent_disk_pool: (( merge ))
   properties:
     metron_agent:
       zone: z1


### PR DESCRIPTION
## What

The graphite machine was using magnetic disks for its persistent disk.
This couldn't keep up with graphite's write load.

In order to specify cloud_properties for a persistent disk it's
[necessary to use disk pools](https://bosh.io/docs/persistent-disks.html), so this PR adds a disk pool for the
graphite persistent disks, and updates the job to use it.

This depends on https://github.com/alphagov/cf-release/pull/3 being
merged first.
## How to review

Deploy to an environment, then verify that all the persistent disk volumes for the graphite machine in the cloudfoundry deployment are of type "gp2" in the AWS console.
## Who can review

Anyone but @actionjack or @alext
