### PR TITLE
[#108616770] Blacklist metrics from smoke tests in graphite

### DIFF
--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -48,6 +48,10 @@ jobs:
     metron_agent:
       zone: z1
     carbon:
+      filter:
+        enable: true
+        blacklist:
+        - stats\.counters\.cfstats\.router_.+\.[0-9]+\.http\..+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.*
       storage_schemas:
         - name: "my_storage_schema"
           pattern: "^my\\.metrics\\.*" # NB: Note the double escapes - this will evaluate to "^my\.metrics\.*"

--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -47,6 +47,8 @@ jobs:
   properties:
     metron_agent:
       zone: z1
+    statsd:
+      deleteIdleStats: true
     carbon:
       filter:
         enable: true

--- a/manifests/templates/stubs/releases.yml
+++ b/manifests/templates/stubs/releases.yml
@@ -2,7 +2,7 @@ releases:
 - name: cf
   version: 215
 - name: graphite
-  version: latest
+  version: 31bd59e43fc542ee3087be54e76567e36f6b191b
 - name: grafana
   version: latest
 - name: collectd

--- a/manifests/templates/stubs/releases.yml
+++ b/manifests/templates/stubs/releases.yml
@@ -4,8 +4,8 @@ releases:
 - name: graphite
   version: 31bd59e43fc542ee3087be54e76567e36f6b191b
 - name: grafana
-  version: latest
+  version: 44564533c9d4d656bdcd5633b808f0bf6fb177ae
 - name: collectd
-  version: latest
+  version: ec9de5dc63715237688c3b27154c86a0c22b3aef
 - name: nginx
-  version: latest
+  version: 2

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -39,7 +39,7 @@ CF_RELEASE_REVISION=gds-paas
 # Releases to upload
 BOSH_RELEASES="
 cf,$CF_RELEASE,https://bosh.io/d/github.com/cloudfoundry/cf-release?v=$CF_RELEASE
-graphite,0d79bf5aa5f2cf29195bff725d7dee55dea1aedc,https://github.com/CloudCredo/graphite-statsd-boshrelease.git,create
+graphite,31bd59e43fc542ee3087be54e76567e36f6b191b,https://github.com/alphagov/graphite-statsd-boshrelease.git,create
 collectd,ec9de5dc63715237688c3b27154c86a0c22b3aef,https://github.com/alphagov/collectd-graphite-boshrelease.git,create
 grafana,44564533c9d4d656bdcd5633b808f0bf6fb177ae,https://github.com/vito/grafana-boshrelease.git,create
 logsearch,23.0.0,https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=23.0.0


### PR DESCRIPTION
# What

Story: https://www.pivotaltracker.com/story/show/108616770

We want to avoid storing the smoke test app metrics which generates  too many useless metrics make graphite really slow. 

Using the fork release of graphite-statsd with customised templates to be able to change the whitelist/blacklist configuration via CF manifest properties. Additionally, we configure `statsd` to not send more values for inactive metrics.
# Context
- I want to use a new version of the graphite release
- and add a filter to blacklist metrics that match the apps named with an UUID 
- I want to enable the option `deleteIdleStats` of statsd to delete metrics that are inactive in statsd. 

Note, as mention in https://github.com/alphagov/graphite-statsd-boshrelease/pull/2, this has the side effect that metrics can have streams of `null` values. This can be alleviated using `keepLastValue` or `transformNull`
# How to review

Deploy the environment `make aws DEPLOY_ENV=...`

If deployed, you can check it by connecting to the graphite host `bosh ssh graphite` and send metrics like:

```
echo "stats.counters.cfstats.router_z1.0.http.requests.031427f0-9ec4-47b6-4544-22c2b05cfbb0_trial_cf_paas_alphagov_co_uk.count 42 `date +%s`" | nc localhost 2003
```

Check the carbon creates log to see wether is creates new metrics or not:

```
tail -f /var/vcap/sys/log/carbon/carbon-cache-a/creates.log
```

For the statsd config, send metrics to statsd

```
echo -n "deploys.test.mycounter:5|c" | nc -w 1 -u 10.0.10.40 8125 # counter
echo -n "deploys.test.mygauge:50|g" | nc -w 1 -u 10.0.10.40 8125 # gauge
```

and check in graphite that the metric is only sent when new values arrive.
# Who can review

Anyone but @saliceti or @keymon 
