### PR TITLE
[#108740280] Disable deployment of kibana app to CF

### DIFF
--- a/manifests/templates/logsearch/stub.yml
+++ b/manifests/templates/logsearch/stub.yml
@@ -42,7 +42,7 @@ properties:
     #
     # But it is not the case, so lets use the public one
     #
-    api_access_security_group: "public"
+    api_access_security_group: "public_networks"
   nats:
     user: nats_user
     password: (( secrets.nats_password ))

--- a/scripts/deploy_logsearch.sh
+++ b/scripts/deploy_logsearch.sh
@@ -93,5 +93,7 @@ if [ "$TARGET_PLATFORM" == gce ]; then
   logsearch_compile_manifest
   logsearch_deploy
 fi
-kibana_deploy
+
+# Disabled until we can fix the excessive disk reads issue
+#kibana_deploy
 


### PR DESCRIPTION
## What

In the current custom kibana app we deploy to CF from logsearch-for-cf
release (the kibana app uses UAA to determine user's orgs and only lets
them see their logs), the app itself is memleaking. This leads to app
being restarted by CF. By itself this isn't a problem, yet currently i
there is 50% chance that the app will issue 100% disk reads just before
being terminated. This can last for hour or for several days. This is
exhausting EBS volume performance and accumulated burst IO and hence
impacting all other apps running on the same DEA. The latest dev release
of the app still behaves the same. Disable the app until we can find a
fix (perhas a CF version update).

This PR also fixes the public access security group name.
## Testing

Apply against existing environment or new one. Verify that push kibana errand doesn't run. In the overview of changes you should see that the security group name has changed from `public` to `public_networks`.
## Applying

This PR doesn't stop or remove already deployed kibanas. This is not necessary in our dev environments (unless you're doing performance tests). But in stage-trial and trial the app should be stopped and removed by hand.
## Reviewing

Anyone from the team but @mtekel.
