### PR TITLE
[#108956530] Strip back provisioning to only provision bosh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,8 @@ ROOT_PASS_DIR ?= .
 all:
 	$(error Usage: make <aws|gce> DEPLOY_ENV=name)
 
-ifeq "$(DEPLOY_ENV)" "trial"
-    SSL_CERTIFICATES_FILE := cloudfoundry/cf-trial-ssl-certificates.yml
-else
-    SSL_CERTIFICATES_FILE := cloudfoundry/cf-dev-ssl-certificates.yml
-endif
-
 check-env-vars:
 	$(if ${DEPLOY_ENV},,$(error Must pass DEPLOY_ENV=<name>))
-	$(if ${WEB_ACCESS_CIDRS},$(eval WEB_ACCESS_OPTION= -var web_access_cidrs=${WEB_ACCESS_CIDRS}))
 
 set-aws: update-paas-pass
 	$(eval dir=aws)
@@ -24,8 +17,8 @@ set-gce: update-paas-pass
 bastion: check-env-vars
 	$(eval bastion=$(shell DEPLOY_ENV=${DEPLOY_ENV} ./scripts/get_bastion_host.sh ${dir}))
 
-aws: check-env-vars set-aws apply prepare-provision-aws provision deploy-cf deploy-logsearch deploy-redis deploy-docker
-gce: check-env-vars set-gce apply prepare-provision-gce provision deploy-cf deploy-logsearch deploy-redis deploy-docker
+aws: check-env-vars set-aws apply prepare-provision-aws provision
+gce: check-env-vars set-gce apply prepare-provision-gce provision
 
 apply-aws: set-aws apply
 apply-gce: set-gce apply
@@ -47,57 +40,15 @@ prepare-provision-gce: set-gce manifests/templates/outputs/terraform-outputs-gce
 prepare-provision: check-env-vars bastion
 	scp -r -oStrictHostKeyChecking=no manifests/templates \
 	    manifests/generate_bosh_manifest.sh \
-	    manifests/generate_deployment_manifest.sh \
-	    manifests/generate_logsearch_manifest.sh \
-	    manifests/generate_docker_manifest.sh \
-	    manifests/generate_redis_manifest.sh \
 	    ubuntu@${bastion}:
 	scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
-	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf-secrets.yml | \
-	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-secrets.yml'
 	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/bosh-secrets.yml | \
 	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/bosh-secrets.yml'
-	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/${SSL_CERTIFICATES_FILE} | \
-	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/cf-ssl-certificates.yml'
-
-test-aws: set-aws test
-test-gce: set-gce test
-test: check-env-vars bastion
-	$(eval domain=$(shell terraform output -state=${dir}/${DEPLOY_ENV}.tfstate dns_zone_name))
-	smoke_test/smoke_test.json.sh \
-	    ${DEPLOY_ENV} ${domain} \
-	    admin `PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf_admin_password` > \
-		smoke_test/smoke_test.json
-	scp -oStrictHostKeyChecking=no \
-	    smoke_test/smoke_test.sh smoke_test/smoke_test.json \
-	    ubuntu@${bastion}:
-	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} \
-	    '/bin/bash smoke_test.sh'
 
 provision-aws: set-aws prepare-provision-aws provision
 provision-gce: set-gce prepare-provision-gce provision
 provision: check-env-vars bastion
 	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/provision.sh ${dir}'
-
-deploy-cf-aws: set-aws prepare-provision-aws deploy-cf
-deploy-cf-gce: set-gce prepare-provision-gce deploy-cf
-deploy-cf: check-env-vars bastion
-	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/deploy_cf.sh ${dir}'
-
-deploy-logsearch-aws: set-aws deploy-logsearch
-deploy-logsearch-gce: set-gce deploy-logsearch
-deploy-logsearch: check-env-vars bastion
-	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/deploy_logsearch.sh ${dir}'
-
-deploy-redis-aws: set-aws deploy-redis
-deploy-redis-gce: set-gce deploy-redis
-deploy-redis: check-env-vars bastion
-	@ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/deploy_redis.sh ${dir}'
-
-deploy-docker-aws: set-aws deploy-docker
-deploy-docker-gce: set-gce deploy-docker
-deploy-docker: check-env-vars bastion
-	@ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/deploy_docker.sh ${dir}'
 
 confirm-execution:
 	@if test "${SKIP_CONFIRM}" = "" ; then \


### PR DESCRIPTION
## What

In order to start prototyping the manifests for the vanilla cloudfoundry deploy, we want a bosh instance deployed to run it against.  This PR strips back the existing deployment to deploy bosh and nothing else.

**Note:** This PR targets the `vanilla_cf_prototype` branch, not `master`
## How to review

Deploy a new environment, and verify that bosh is deployed.  No releases, stemcells or deployments should be created within this bosh.
## Who can review

Anyone but @alext and @Jonty.
