### PR TITLE
[#108968418] add logsearch kibana and proxy

### DIFF
--- a/manifests/templates/logsearch/logsearch-minimal-jobs.yml
+++ b/manifests/templates/logsearch/logsearch-minimal-jobs.yml
@@ -17,6 +17,8 @@ properties:
     user: (( merge ))
     port: (( merge || 4222 ))
     machines: (( merge ))
+  kibana:
+    elasticsearch: (( meta.elasticsearch_master_host ":9200" ))
   curator:
     <<: (( merge ))
     elasticsearch_host: (( meta.elasticsearch_master_host ))
@@ -69,6 +71,7 @@ jobs:
   - { release: logsearch, name: parser }
   - { release: logsearch, name: ingestor_syslog }
   - { release: logsearch, name: ingestor_relp }
+  - { release: logsearch, name: kibana }
   - { release: logsearch-for-cloudfoundry, name: ingestor_cloudfoundry-firehose }
   - { release: cf, name: collector }
   instances: 1

--- a/scripts/deploy_kibana_proxy.sh
+++ b/scripts/deploy_kibana_proxy.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+if [[ -n $(cf app logs | grep running) ]] ; then
+  echo "Kibana proxy seems to be running already, skipping deploy..."
+  exit 0
+fi
+
+echo "*** Deploying and starting Kibana proxy..."
+CF_ADMIN="$1"
+CF_PASS="$2"
+KIBANA_PASSWORD="$3"
+KIBANA_SERVER=`python -c 'import yaml; print yaml.load(file("logsearch-manifest.yml"))["meta"]["elasticsearch_master_host"]'`
+DOMAIN=`python -c 'import yaml; print yaml.load(file("cf-manifest.yml"))["properties"]["domain"]'`
+
+echo "*** Logging in to CF and creating admin space..."
+cf api --skip-ssl-validation https://api.${DOMAIN}
+echo | cf login -u ${CF_ADMIN} -p ${CF_PASS}
+echo | cf create-org admin
+cf create-space admin -o admin
+cf target -o admin -s admin
+
+# Create the proxy app
+mkdir -p kibana-proxy && cd kibana-proxy
+
+htpasswd -b -c pw kibana ${KIBANA_PASSWORD}
+
+cat <<EOF >nginx.conf
+worker_processes 1;
+daemon off;
+events { worker_connections 1024; }
+error_log stderr;
+http {
+  port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
+  server_tokens off;
+  server {
+    listen <%= ENV["PORT"] %>;
+    server_name localhost;
+    location / {
+      proxy_set_header Host kibana;
+      proxy_pass http://<%= ENV["KIBANA_SERVER"] %>/;
+      auth_basic "KIBANA!";
+      auth_basic_user_file ../../pw;
+    }
+  }
+}
+EOF
+
+cat <<EOF > manifest.yml
+---
+applications:
+- name: logs
+  memory: 100M
+  disk: 100M
+  instances: 1
+  buildpack: staticfile_buildpack
+EOF
+
+cf push --no-start
+cf set-env logs KIBANA_SERVER ${KIBANA_SERVER}
+
+cat <<EOF > kibana-proxy.json
+[{"protocol":"tcp","destination":"${KIBANA_SERVER}","ports":"80,9200"}]
+EOF
+cf create-security-group kibana-proxy kibana-proxy.json
+cf bind-staging-security-group kibana-proxy
+cf bind-running-security-group kibana-proxy
+
+cf push 

--- a/scripts/deploy_logsearch.sh
+++ b/scripts/deploy_logsearch.sh
@@ -3,7 +3,7 @@
 set -e # fail on error
 
 SCRIPT_DIR=$(cd $(dirname $0) && pwd)
-
+get_cf_secret() { ${SCRIPT_DIR}/val_from_yaml.rb templates/cf-secrets.yml $1; }
 
 # Read the platform configuration
 TARGET_PLATFORM=$1
@@ -96,4 +96,9 @@ fi
 
 # Disabled until we can fix the excessive disk reads issue
 #kibana_deploy
+
+# Deploy kibana proxy that gives access via usual CF domain and provides basic auth
+time bash $SCRIPT_DIR/deploy_kibana_proxy.sh admin \
+  $(get_cf_secret secrets/uaa_admin_password) \
+  $(get_cf_secret secrets/kibana_oauth2_client_secret)
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -87,6 +87,7 @@ install_dependencies() {
     unzip
     bundler
     jq
+    apache2-utils
   "
 
   echo "Installing system packages..."


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/n/projects/1275640/stories/108968418)
### What

Add the original, unmodified kibana to logsearch. To make access to this kibana easy, deploy proxy app to CF which adds basic auth on top.
### Testing

Apply to existing env. or build from scratch. Verify you can access kibana on `logs.<environment domain>`. The password is same as the UAA enabled Kibana secret (see pass secrets or secrets.yml on bastion). User is kibana.
### Who

Anyone but @mtekel.
