### PR TITLE
[#108615900] Prune metrics

### DIFF
--- a/manifests/templates/deployments/graphite.yml
+++ b/manifests/templates/deployments/graphite.yml
@@ -50,6 +50,7 @@ jobs:
     statsd:
       deleteIdleStats: true
     carbon:
+      prune_delay: 10
       filter:
         enable: true
         blacklist:

--- a/manifests/templates/stubs/releases.yml
+++ b/manifests/templates/stubs/releases.yml
@@ -2,7 +2,7 @@ releases:
 - name: cf
   version: 215
 - name: graphite
-  version: 31bd59e43fc542ee3087be54e76567e36f6b191b
+  version: 1e8ecd7c7a051c191792e8d440c9a4d0b89c2302
 - name: grafana
   version: 44564533c9d4d656bdcd5633b808f0bf6fb177ae
 - name: collectd

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -39,7 +39,7 @@ CF_RELEASE_REVISION=gds-paas
 # Releases to upload
 BOSH_RELEASES="
 cf,$CF_RELEASE,https://bosh.io/d/github.com/cloudfoundry/cf-release?v=$CF_RELEASE
-graphite,31bd59e43fc542ee3087be54e76567e36f6b191b,https://github.com/alphagov/graphite-statsd-boshrelease.git,create
+graphite,1e8ecd7c7a051c191792e8d440c9a4d0b89c2302,https://github.com/alphagov/graphite-statsd-boshrelease.git,create
 collectd,ec9de5dc63715237688c3b27154c86a0c22b3aef,https://github.com/alphagov/collectd-graphite-boshrelease.git,create
 grafana,44564533c9d4d656bdcd5633b808f0bf6fb177ae,https://github.com/vito/grafana-boshrelease.git,create
 logsearch,23.0.0,https://bosh.io/d/github.com/logsearch/logsearch-boshrelease?v=23.0.0


### PR DESCRIPTION
# What
- Update graphite release for the prune metrics feature
- Set `prune_delay` to 10 days. Inactive metrics will be deleted after this time
# How to review

```
make aws DEPLOY_ENV=<environment>
```
- Check the graphite VM was updated:

```
# ls -l /etc/cron.daily/
total 44
-rwxr-xr-x 1 root root   311 Feb 20  2014 0anacron
-rwxr-xr-x 1 root root 15481 Apr 10  2014 apt
-rwxr-xr-x 1 root root   355 Jun  4  2013 bsdmainutils
-rwxr-xr-x 1 root root   256 Mar  7  2014 dpkg
-rwxr-xr-x 1 root root   249 Feb 17  2014 passwd
lrwxrwxrwx 1 root root    39 Nov 30 10:18 prune_metrics -> /var/vcap/jobs/carbon/bin/prune_metrics
-rwxr-xr-x 1 root root   349 Dec 27  2012 quota
-rwxr-xr-x 1 root root   441 Nov 10  2013 sysstat
-rwxr-xr-x 1 root root   328 Jul 18  2014 upstart
```
# Who can review

Anyone but @saliceti or @jimconner 
