### PR TITLE
Increase DEA resource limits

### DIFF
--- a/manifests/templates/stubs/cf-stub.yml
+++ b/manifests/templates/stubs/cf-stub.yml
@@ -43,8 +43,8 @@ properties:
     user: nats_user
     password: (( secrets.nats_password ))
   dea_next:
-    disk_mb: 10240
-    memory_mb: 4096
+    disk_mb: 60240
+    memory_mb: 8192
   router:
     enable_ssl: true
     port: 8090 # We bind router on port 8090 as it's not wanted, but we can't disable it


### PR DESCRIPTION
The limits were set to 10G disk and 4G (x3 overprovision) memory. We
run r3.large DEAs with 15G of ram and 100G of disk, out of which 80G
is available. Increasing resource limits conservatively to 60G disk and
8G (x3 default oveprovision) memory. The apps usually consume 50-70% of
memory and even less of disk allowance, so these limits are safe.

We have hit the lower limits now, smoketests sporadically failing on not enough disk space, whereas there's plenty of disk space available on DEAs in reality...

(see https://deploy.tools.paas.alphagov.co.uk/job/trial-cf-smoke-test-aws/18156/console)
