### PR TITLE
[#109509946] Logsearch: set ELS replicas to 0

### DIFF
--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -314,7 +314,7 @@ properties:
               "order" : 50,
               "settings" : {
               "number_of_shards" : 5,
-              "number_of_replicas" : 1,
+              "number_of_replicas" : 0,
               "index" : {
                       "search" : {
                   "slowlog" : {


### PR DESCRIPTION
### What

We run logsearch on a single host, which also hosts elasticsearch.
Because of this, having shard replicas is pointless, as there is no
other elasticsearch server to replicate to. Yet when you set replicas
to 1, replicas will still be created. This means that the cluster
status will be yellow (as replicas are not replicated) and the mem/
disk space consumption would be larger, as we have 2 copies of data.

Set replicas to 0 to make server faster (less data to manage by
removing duplicate data). The cluster status will still be yellow, as 4.1.1
kibana has 2 replicas hard-coded. This should be user configurable
from 4.2.2 kibana. As of today, latest logsearch release still contains
only kibana 4.1.1.
### Testing

The new setting applies only to new shards (it tells how many replicas to create on shard creation). You need thus to build logsearch from scratch. Verifly by doing `curl 'http://10.0.40.10:9200/_cat/indices?v'`. The rep column should be 0. Check cluster health status by `curl 'http://10.0.40.10:9200/_cluster/health?pretty=true'`. You should get st. like

```
{
  "cluster_name" : "logsearch-michael",
  "status" : " yellow",
  "timed_out" : false,
  "number_of_nodes" : 2,
  "number_of_data_nodes" : 1,
  "active_primary_shards" : 5,
  "active_shards" : 5,
  "relocating_shards" : 0,
  "initializing_shards" : 0,
  "unassigned_shards" : 0,
  "delayed_unassigned_shards" : 0,
  "number_of_pending_tasks" : 0,
  "number_of_in_flight_fetch" : 0
}
```
### Applying:
- Has been applied to trial already
- Will be applied to staging after 7 days, as new indexes are created for every day and we keep only week worth of logs
- If you don't want to wait for 7 days, you can use this script

```
for index in $(curl -s localhost:9200/_cat/indices? | awk '{print $3}'); do

curl -XPUT localhost:9200/$index/_settings -d '
{
   "index" : {
       "number_of_replicas" : 0
   }
}'
done
```
### Reviewing

not @mtekel or @combor 
