### PR TITLE
[#108528644] Improve generic manifest tests

### DIFF
--- a/cf-manifest/spec/manifest_validation_spec.rb
+++ b/cf-manifest/spec/manifest_validation_spec.rb
@@ -2,6 +2,11 @@
 RSpec.describe "generic manifest validations" do
   let(:manifest) { manifest_with_defaults }
 
+  specify "it must have a name" do
+    expect(manifest["name"]).to be
+    expect(manifest["name"]).to match(/\S+/)
+  end
+
   describe "name uniqueness" do
     %w(
       disk_pools

--- a/cf-manifest/spec/manifest_validation_spec.rb
+++ b/cf-manifest/spec/manifest_validation_spec.rb
@@ -86,5 +86,12 @@ RSpec.describe "generic manifest validations" do
           "network #{pool["network"]} not found for resource_pool #{pool["name"]}"
       end
     end
+
+    specify "the compilation pool references a network that exists" do
+      network_names = manifest["networks"].map {|n| n["name"]}
+
+      expect(network_names).to include(manifest["compilation"]["network"]),
+        "network #{manifest["compilation"]["network"]} not found for compilation resource_pool"
+    end
   end
 end

--- a/cf-manifest/spec/manifest_validation_spec.rb
+++ b/cf-manifest/spec/manifest_validation_spec.rb
@@ -1,3 +1,4 @@
+require 'ipaddr'
 
 RSpec.describe "generic manifest validations" do
   let(:manifest) { manifest_with_defaults }
@@ -59,13 +60,47 @@ RSpec.describe "generic manifest validations" do
       end
     end
 
-    specify "all jobs reference networks that exist" do
-      network_names = manifest["networks"].map {|n| n["name"]}
+    describe "networks" do
+      let(:networks_by_name) {
+        manifest["networks"].each_with_object({}) { |net, result| result[net["name"]] = net }
+      }
+      let(:network_names) { networks_by_name.keys }
 
-      manifest["jobs"].each do |job|
-        job["networks"].each do |network|
-          expect(network_names).to include(network["name"]),
-            "network #{network["name"]} not found for job #{job["name"]}"
+      specify "all jobs reference networks that exist" do
+        manifest["jobs"].each do |job|
+          job["networks"].each do |network|
+            expect(network_names).to include(network["name"]),
+              "network #{network["name"]} not found for job #{job["name"]}"
+          end
+        end
+      end
+
+      specify "all jobs' static IPs are within the corresponding network's static ranges" do
+        network_static_ranges = networks_by_name.each_with_object({}) do |(name, network), results|
+          results[name] = []
+          network.fetch("subnets").each do |subnet|
+            subnet.fetch("static", []).each do |static|
+              if static =~ /\s*-\s*/
+                first, last = static.split(/\s*-\s*/, 2)
+                results[name] << Range.new(IPAddr.new(first), IPAddr.new(last))
+              else
+                results[name] << IPAddr.new(static)
+              end
+            end
+          end
+        end
+
+        manifest["jobs"].each do |job|
+          job["networks"].each do |job_network|
+            next unless job_network["static_ips"]
+
+            static_ranges = network_static_ranges.fetch(job_network["name"])
+            job_network["static_ips"].each do |ip|
+              expect(
+                static_ranges.any? {|r| r.is_a?(Range) ? r.include?(ip) : r == ip }
+              ).to be_truthy, "IP #{ip} not in static range for network #{job_network["name"]} in job #{job["name"]}"
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
:rotating_light: **Note:** This is a PR against `vanilla_cf_prototype`, not `master`
## What

Cover some more details in the generic bosh manifest tests.  Specifically:
- the compilation pool references a network that exists
- the manifest has a name
- all jobs use static IPs that are inside the corresponding network's range.
## How to review

Check that the new tests look sensible (may be easier to view the diff with `?w=1` in the URL).

Run the tests to check they pass. (`bundle exec rspec` from the cf-manifest directory)
## Who can review

Anyone but me.
