### PR TITLE
Update README instructions around spruce.

### DIFF
--- a/cf-manifest/README.md
+++ b/cf-manifest/README.md
@@ -3,7 +3,7 @@
 ### Dependencies
 
 This requires [spruce](https://github.com/geofffranks/spruce#readme) (commit
-`f828349` or later). If you have a working Go installation, this can be
+`6b89bc7` or later). If you have a working Go installation, this can be
 installed/updated with:
 
-    go get -u geofffranks/spruce
+    go get -u github.com/geofffranks/spruce


### PR DESCRIPTION
The import path was missing the `github.com/` prefix. Also there's
another bugxif that we need, so I've updated the minumum commit needed.
