### PR TITLE
[#109806354] Implement IAM instance profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,11 @@ gce/
         insecure-deployer.pub
 ```
 * Provide `account.json` inside gce
-* On AWS: Provide AWS access keys as environment variables, plus the corresponding terraform variables. Example in profile:
+* On AWS: Provide AWS access keys as environment variables. Example in profile:
 
 ```
 export AWS_ACCESS_KEY_ID=XXXXXXXXXX
 export AWS_SECRET_ACCESS_KEY=YYYYYYYYYY
-export TF_VAR_AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-export TF_VAR_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 ```
 
 * On GCE: Pass the AWS credentials to access the shared compile package bucket

--- a/aws/bastion.tf
+++ b/aws/bastion.tf
@@ -5,6 +5,7 @@ resource "aws_instance" "bastion" {
   private_ip = "10.0.0.4"
   associate_public_ip_address = true
   vpc_security_group_ids = ["${aws_security_group.bastion.id}"]
+  iam_instance_profile = "bosh-bootstrap"
   key_name = "${var.key_pair_name}"
   source_dest_check = false
 

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -82,22 +82,6 @@ output "key_pair_name" {
 	value = "${var.key_pair_name}"
 }
 
-output "aws_secret_access_key" {
-	value = "${var.AWS_SECRET_ACCESS_KEY}"
-}
-
-output "aws_access_key_id" {
-       value = "${var.AWS_ACCESS_KEY_ID}"
-}
-
-output "compiled_cache_bucket_access_key_id" {
-	value = "${var.AWS_ACCESS_KEY_ID}"
-}
-
-output "compiled_cache_bucket_secret_access_key" {
-	value = "${var.AWS_SECRET_ACCESS_KEY}"
-}
-
 output "compiled_cache_bucket_host" {
 	value = "s3-${var.region}.amazonaws.com"
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -91,15 +91,3 @@ variable "dns_zone_name" {
   description = "Amazon Route53 DNS zone name"
   default     = "cf.paas.alphagov.co.uk"
 }
-
-# Terraform currently only has limited support for reading environment variables
-# Variables for use with terraform must be prefexed with 'TF_VAR_'
-# These two variables are passed in as environment variables named:
-# TF_VAR_AWS_ACCESS_KEY_ID and TF_VAR_AWS_SECRET_ACCESS_KEY respectively
-variable "AWS_ACCESS_KEY_ID" {
-  description = "AWS access key to be pass to the bosh CPI"
-}
-
-variable "AWS_SECRET_ACCESS_KEY" {
-  description = "AWS secret access key to be pass to the bosh CPI"
-}

--- a/manifests/templates/aws/bosh/bosh-manifest.yml
+++ b/manifests/templates/aws/bosh/bosh-manifest.yml
@@ -7,8 +7,7 @@ meta:
   bosh_service_ip: (( bosh_private_ip ))
 
   aws:
-    access_key_id: (( terraform_outputs.aws_access_key_id ))
-    secret_access_key: (( terraform_outputs.aws_secret_access_key ))
+    credentials_source: env_or_profile
     default_key_name: (( terraform_outputs.key_pair_name ))
     default_security_groups:
     - (( terraform_outputs.default_security_group ))
@@ -40,6 +39,7 @@ resource_pools:
     instance_type: t2.medium
     ephemeral_disk: {size: 40_000, type: gp2}
     availability_zone: (( terraform_outputs.zone0 ))
+    iam_instance_profile: bosh-director
 
 disk_pools:
 - name: disks

--- a/manifests/templates/aws/bosh/bosh-manifest.yml
+++ b/manifests/templates/aws/bosh/bosh-manifest.yml
@@ -16,12 +16,12 @@ meta:
 
   cpi-release:
     name: bosh-aws-cpi
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=28
-    sha1: c7ce03393ebedd87a860dc609758ddb9654360fa
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=36
+    sha1: db2a6c6cdd5ff9f77bf083e10118fa72e1f5e181
 
   specific_bosh_job_templates:
     - {name: registry, release: bosh}
-    - {name: cpi, release: bosh-aws-cpi}
+    - {name: aws_cpi, release: bosh-aws-cpi}
 
   ntp:
   - 0.pool.ntp.org
@@ -73,7 +73,7 @@ jobs:
 
 cloud_provider:
   template:
-    name: cpi
+    name: aws_cpi
     release: bosh-aws-cpi
 
   properties:

--- a/manifests/templates/aws/cf-pool-instances.yml
+++ b/manifests/templates/aws/cf-pool-instances.yml
@@ -32,6 +32,16 @@ resource_pools:
   - name: large_z2
     cloud_properties: (( meta.resource_pools.large.cloud_properties ))
 
+  - name: api_z1
+    cloud_properties:
+      instance_type: (( meta.resource_pools.large.cloud_properties.instance_type ))
+      iam_instance_profile: cf-cloudcontroller
+
+  - name: api_z2
+    cloud_properties:
+      instance_type: (( meta.resource_pools.large.cloud_properties.instance_type ))
+      iam_instance_profile: cf-cloudcontroller
+
   - name: runner_z1
     cloud_properties: (( meta.resource_pools.runner.cloud_properties ))
 

--- a/manifests/templates/aws/stubs/cf-stub-aws.yml
+++ b/manifests/templates/aws/stubs/cf-stub-aws.yml
@@ -65,8 +65,7 @@ properties:
       app_package_directory_key: (( terraform_outputs.environment "-cf-packages" ))
   template_only:
     aws:
-      access_key_id: (( terraform_outputs.aws_access_key_id ))
-      secret_access_key: (( terraform_outputs.aws_secret_access_key ))
+      use_iam_profile: true
       availability_zone: (( terraform_outputs.zone0 ))
       availability_zone2: (( terraform_outputs.zone1 ))
   databases:
@@ -77,6 +76,12 @@ properties:
     transport: relp
 
 jobs:
+  - name: api_z1
+    resource_pool: api_z1
+
+  - name: api_z2
+    resource_pool: api_z2
+
   - name: postgres_z1
     instances: 1
     networks:

--- a/manifests/templates/aws/stubs/cf-stub-aws.yml
+++ b/manifests/templates/aws/stubs/cf-stub-aws.yml
@@ -7,6 +7,8 @@ meta:
     z1: (( terraform_outputs.zone0 ))
     z2: (( terraform_outputs.zone1 ))
   fog_config:
+    use_iam_profile: true
+    provider: AWS
     region: (( terraform_outputs.region ))
 
 networks:
@@ -65,7 +67,6 @@ properties:
       app_package_directory_key: (( terraform_outputs.environment "-cf-packages" ))
   template_only:
     aws:
-      use_iam_profile: true
       availability_zone: (( terraform_outputs.zone0 ))
       availability_zone2: (( terraform_outputs.zone1 ))
   databases:

--- a/manifests/templates/bosh/bosh-template.yml
+++ b/manifests/templates/bosh/bosh-template.yml
@@ -47,8 +47,8 @@ name: (( merge ))
 
 releases:
 - name: bosh
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=207
-  sha1: 5f835bad5fc46230cd2fa823c0a52a94829ee044
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=208
+  sha1: 0c84b104d9252295597a9fbcabdf432b6f1bd226
 - (( meta.cpi-release ))
 
 resource_pools: (( merge ))
@@ -115,7 +115,7 @@ jobs:
       address: 127.0.0.1
       name: my-bosh
       db: (( meta.postgres ))
-      cpi_job: cpi
+      cpi_job: (( cloud_provider.template.name || "cpi" ))
       ignore_missing_gateway: "false"
       user_management:
         provider: local

--- a/manifests/templates/bosh/bosh-template.yml
+++ b/manifests/templates/bosh/bosh-template.yml
@@ -80,8 +80,7 @@ jobs:
     compiled_package_cache:
       provider: s3
       options:
-        access_key_id: (( terraform_outputs.compiled_cache_bucket_access_key_id ))
-        secret_access_key: (( terraform_outputs.compiled_cache_bucket_secret_access_key ))
+        credentials_source: env_or_profile
         bucket_name: shared-cf-bosh-blobstore
         host: (( terraform_outputs.compiled_cache_bucket_host ))
 


### PR DESCRIPTION
[Create IAM profiles and roles to allow contact the AWS API from BOSH/Terraform VMS](https://www.pivotaltracker.com/story/show/109806354)
## What

We want to secure our AWS API and reduce the risk of leaking credentials
by using [AIM instace profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html).

This will also simplify our configuration, as we don't need to pass credentials
anymore.

More info: https://bosh.io/docs/aws-iam-instance-profiles.html
## Dependencies

https://github.com/alphagov/cf-release/pull/5 must be merge first.
## Context

I want to implement IAM profiles to all the process of deploying cloudfoundry
and get a functional environmnent without credentials in configuration.

For that I need to:
- Create Roles and policies (see card and commits for details). These were
  created manually by operators with permissions. The roles are:
  - bosh-bootstrap: For the machine which runs terraform & bosh-init.
  - bosh-director: For the bosh director running the CPI
  - cf-cloudcontroller: for the Cloudfoundry APIs
- Setup IAM profile for the bastion host using terraform
- Setup IAM profile for microbosh when deploying with bosh init
- Remove AWS credentials in the microbosh config
- Setup IAM profile for API nodes to access the S3 assets. That required
  changes in the cf-release (see https://github.com/alphagov/cf-release/pull/4
  and https://github.com/alphagov/cf-release/pull/5) which add a new resource
  pool for the API vms with a custom IAM profile.
## How to test?
1. Deploy the environment as usual: `make aws DEPLOY_ENV=...`
2. Verify that no generated manifest has the AWS credentials.
3. Run the tests: `make test-aws DEPLOY_ENV=...`
## How to apply these changes to the running environments?

The IAM roles can only being associated during VM creation, which means that we must recreate the following VMs to be able to apply the changes:
- bastion
- bosh vm
- api_z1

As we don't store the bosh-init state, and the bosh machine does not get redeployed despite manifest changes, the process to upgrade a running environment would slightly more complex:
1. Backup the `bosh-manifest-state.json` state file for bosh-init in your local system, as bastion will be destroyed (`scp ubuntu@<DEPLOY_ENV>-bastion.cf.paas.alphagov.co.uk:bosh-manifest-state.json .`)
2. Apply terraform to recreate the bastion: `make apply-aws DEPLOY_ENV=...`
3. Restore the bastion state: `scp bosh-manifest-state.json  ubuntu@<DEPLOY_ENV>-bastion.cf.paas.alphagov.co.uk:`
4. ssh to the bastion and rerun bosh init: `make ssh-aws DEPLOY_ENV=...` and `bosh-init deploy bosh-manifest.yml`

Finally, apply the changes for CF. Just run: `make aws DEPLOY_ENV=...`
## Who can review it?

Anyone but @timmow or @keymon
