### PR TITLE
[#108528644] Document intent for manifests in README.

### DIFF
--- a/cf-manifest/README.md
+++ b/cf-manifest/README.md
@@ -1,5 +1,14 @@
 ## Cloud Foundry manifests.
 
+These have been taken from the upstream [cf-release
+repository](https://github.com/cloudfoundry/cf-release), and adapted to use
+spruce.
+
+The intention is that these will be developed with a focus on ease of
+understanding and maintainability, instead of keeping in sync with upstream.
+This means that we are editing these files rather than adding additional layers
+in spruce.
+
 ### Dependencies
 
 This requires [spruce](https://github.com/geofffranks/spruce#readme) (commit


### PR DESCRIPTION
:rotating_light: **Note:** This is a PR against `vanilla_cf_prototype`, not `master`

Capture the source of the manifests, and the intent for how we plan to
manage these in the README.
