### PR TITLE
[#110234536] Run CF dployment using new manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ set-gce: update-paas-pass
 bastion: check-env-vars
 	$(eval bastion=$(shell DEPLOY_ENV=${DEPLOY_ENV} ./scripts/get_bastion_host.sh ${dir}))
 
-aws: check-env-vars set-aws apply prepare-provision-aws provision
+aws: check-env-vars set-aws apply prepare-provision-aws provision deploy-cf
 gce: check-env-vars set-gce apply prepare-provision-gce provision
 
 apply-aws: set-aws apply
@@ -28,6 +28,8 @@ apply: check-env-vars
 
 manifests/templates/outputs/terraform-outputs-aws.yml: check-env-vars aws/${DEPLOY_ENV}.tfstate
 	./scripts/extract_terraform_outputs_to_yml.rb < aws/${DEPLOY_ENV}.tfstate > manifests/templates/outputs/terraform-outputs-aws.yml
+cf-manifest/outputs/terraform-outputs.yml: check-env-vars aws/${DEPLOY_ENV}.tfstate
+	./scripts/extract_terraform_outputs_to_yml.rb < aws/${DEPLOY_ENV}.tfstate > cf-manifest/outputs/terraform-outputs.yml
 manifests/templates/outputs/terraform-outputs-gce.yml: check-env-vars gce/${DEPLOY_ENV}.tfstate
 	./scripts/extract_terraform_outputs_to_yml.rb < gce/${DEPLOY_ENV}.tfstate > manifests/templates/outputs/terraform-outputs-gce.yml
 scripts/terraform-outputs-aws.sh: check-env-vars aws/${DEPLOY_ENV}.tfstate
@@ -35,21 +37,27 @@ scripts/terraform-outputs-aws.sh: check-env-vars aws/${DEPLOY_ENV}.tfstate
 scripts/terraform-outputs-gce.sh: check-env-vars gce/${DEPLOY_ENV}.tfstate
 	./scripts/extract_terraform_outputs_to_sh.rb < gce/${DEPLOY_ENV}.tfstate > scripts/terraform-outputs-gce.sh
 
-prepare-provision-aws: set-aws manifests/templates/outputs/terraform-outputs-aws.yml scripts/terraform-outputs-aws.sh prepare-provision
+prepare-provision-aws: set-aws manifests/templates/outputs/terraform-outputs-aws.yml cf-manifest/outputs/terraform-outputs.yml scripts/terraform-outputs-aws.sh prepare-provision
 prepare-provision-gce: set-gce manifests/templates/outputs/terraform-outputs-gce.yml scripts/terraform-outputs-gce.sh prepare-provision
 prepare-provision: check-env-vars bastion
+	scp -r -oStrictHostKeyChecking=no cf-manifest \
+	    ubuntu@${bastion}:
 	scp -r -oStrictHostKeyChecking=no manifests/templates \
 	    manifests/generate_bosh_manifest.sh \
 	    ubuntu@${bastion}:
 	scp -r -oStrictHostKeyChecking=no scripts ubuntu@${bastion}:
+	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf-secrets.yml | \
+	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > cf-manifest/outputs/cf-secrets.yml'
 	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/bosh-secrets.yml | \
 	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > templates/bosh-secrets.yml'
-
+	PASSWORD_STORE_DIR=~/.paas-pass pass ${ROOT_PASS_DIR}/cloudfoundry/cf-trial-ssl-certificates.yml | \
+	    ssh -oStrictHostKeyChecking=no ubuntu@${bastion} 'cat > cf-manifest/outputs/cf-ssl-certificates.yml'
 provision-aws: set-aws prepare-provision-aws provision
 provision-gce: set-gce prepare-provision-gce provision
 provision: check-env-vars bastion
 	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/provision.sh ${dir}'
-
+deploy-cf: check-env-vars bastion
+	ssh -t -oStrictHostKeyChecking=no ubuntu@${bastion} '/bin/bash ./scripts/deploy_cf.sh aws'
 confirm-execution:
 	@if test "${SKIP_CONFIRM}" = "" ; then \
 		read -sn 1 -p "This is a destructive operation, are you sure you want to do this [Y/N]? "; [[ $${REPLY:0:1} = [Yy] ]]; \

--- a/cf-manifest/build_manifest.sh
+++ b/cf-manifest/build_manifest.sh
@@ -6,6 +6,7 @@ cd $(dirname $0)
 terraform_outputs=${TERRAFORM_OUTPUTS:-"outputs/terraform-outputs.yml"}
 secrets=${SECRETS:-"outputs/cf-secrets.yml"}
 ssl_certs=${SSL_CERTS:-"outputs/cf-ssl-certificates.yml"}
+director_uuid=${DIRECTOR_UUID:-"outputs/director-uuid.yml"}
 
 spruce merge \
   --prune meta --prune lamb_meta \
@@ -15,4 +16,5 @@ spruce merge \
   deployments/aws/*.yml \
   ${terraform_outputs} \
   ${secrets} \
-  ${ssl_certs}
+  ${ssl_certs} \
+  ${director_uuid}

--- a/cf-manifest/deployments/030-cf-jobs.yml
+++ b/cf-manifest/deployments/030-cf-jobs.yml
@@ -291,7 +291,7 @@ jobs:
 
   - name: postgres_z1
     templates: (( grab meta.postgres_templates ))
-    instances: 0
+    instances: 1
     resource_pool: medium_z1
     persistent_disk: 4096
     networks:
@@ -667,7 +667,24 @@ properties:
 
   ha_proxy:
 
-  databases: ~
+  databases:
+     db_scheme: postgres
+     address: ~
+     port: 5524
+     roles:
+       - tag: admin
+         name: ccadmin
+         password: (( grab secrets.ccadmin_password ))
+       - tag: admin
+         name: uaaadmin
+         password: (( grab secrets.uuadmin_password ))
+     databases:
+       - tag: cc
+         name: ccdb
+         citext: true
+       - tag: uaa
+         name: uaadb
+         citext: true
 
   router:
     enable_ssl:

--- a/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -173,6 +173,12 @@ jobs:
       - name: cf2
         static_ips: (( static_ips(5, 6, 15, 16, 17, 18, 19, 20) ))
 
+  - name: postgres_z1
+    instances: 1
+    networks:
+      - name: cf1
+        static_ips: (( static_ips(7) ))
+
   - name: loggregator_z1
     instances: 0
     networks:

--- a/cf-manifest/deployments/aws/999-cf-stub.yml
+++ b/cf-manifest/deployments/aws/999-cf-stub.yml
@@ -90,13 +90,13 @@ properties:
         - (( concat "admin|" secrets.uaa_admin_password "|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose" ))
 
   ccdb:
-    db_scheme: postgresql
-    address: (( grab terraform_outputs.postgres_rds_address ))
-    port: (( grab terraform_outputs.postgres_rds_port ))
+    db_scheme: postgres
+    address: (( grab jobs.postgres_z1.networks.cf1.static_ips.[0] ))
+    port: 5524
     roles:
       - tag: admin
         name: ccadmin
-        password: (( secrets.ccadmin_password ))
+        password: (( grab secrets.ccadmin_password ))
     databases:
       - tag: cc
         name: ccdb
@@ -104,16 +104,18 @@ properties:
 
   uaadb:
     db_scheme: postgresql
-    address: (( grab terraform_outputs.postgres_rds_address ))
-    port: (( grab terraform_outputs.postgres_rds_port ))
+    address: (( grab jobs.postgres_z1.networks.cf1.static_ips.[0] ))
+    port: 5524
     roles:
       - tag: admin
         name: uaaadmin
-        password: (( secrets.uuadmin_password ))
+        password: (( grab secrets.uuadmin_password ))
     databases:
       - tag: uaa
         name: uaadb
         citext: true
 
+  databases:
+    address: (( grab jobs.postgres_z1.networks.cf1.static_ips.[0] ))
 # code_snippet cf-stub-aws end
 # The previous line helps maintain current documentation at http://docs.cloudfoundry.org.

--- a/cf-manifest/deployments/aws/999-cf-stub.yml
+++ b/cf-manifest/deployments/aws/999-cf-stub.yml
@@ -12,31 +12,27 @@ director_uuid: DIRECTOR_UUID
 networks:
 - name: cf1
   subnets:
-    - range: 10.10.16.0/20
+    - range: 10.0.10.0/24
       reserved:
-        - 10.10.16.2 - 10.10.16.9
+        - 10.0.10.2 - 10.0.10.9
       static:
-        - 10.10.16.10 - 10.10.16.255
-      gateway: 10.10.16.1
+        - 10.0.10.10 - 10.0.10.40
+      gateway: 10.0.10.1
       dns:
-        - 10.10.0.2
+        - 10.0.0.2
       cloud_properties:
-        security_groups:
-          - cf
         subnet: (( grab terraform_outputs.cf1_subnet_id ))
 - name: cf2
   subnets:
-    - range: 10.10.80.0/20
+    - range: 10.0.11.0/24
       reserved:
-        - 10.10.80.2 - 10.10.80.9
+        - 10.0.11.2 - 10.0.11.9
       static:
-        - 10.10.80.10 - 10.10.80.255
-      gateway: 10.10.80.1
+        - 10.0.11.10 - 10.0.11.40
+      gateway: 10.0.11.1
       dns:
-        - 10.10.0.2
+        - 10.0.0.2
       cloud_properties:
-        security_groups:
-          - cf
         subnet: (( grab terraform_outputs.cf2_subnet_id ))
 
 properties:

--- a/cf-manifest/spec/fixtures/director-uuid.yml
+++ b/cf-manifest/spec/fixtures/director-uuid.yml
@@ -1,0 +1,2 @@
+---
+director_uuid: 111a11b1-1a1b-111f-a111-111111d11b1d

--- a/cf-manifest/spec/support/manifest_helpers.rb
+++ b/cf-manifest/spec/support/manifest_helpers.rb
@@ -20,6 +20,7 @@ module ManifestHelpers
         "TERRAFORM_OUTPUTS" => File.expand_path("../../fixtures/terraform-outputs.yml", __FILE__),
         "SECRETS"           => File.expand_path("../../fixtures/cf-secrets.yml", __FILE__),
         "SSL_CERTS"         => File.expand_path("../../fixtures/cf-ssl-certificates.yml", __FILE__),
+        "DIRECTOR_UUID"         => File.expand_path("../../fixtures/director-uuid.yml", __FILE__),
       },
       File.expand_path("../../../build_manifest.sh", __FILE__),
     )

--- a/scripts/deploy_cf.sh
+++ b/scripts/deploy_cf.sh
@@ -37,10 +37,10 @@ cf_compile_manifest() {
   cd ~
 
   # Output the director uuid to be populated by spiff
-  echo -e "---\ndirector_uuid: $($BOSH_CLI status --uuid)" > templates/stubs/director-uuid.yml
+  echo -e "---\ndirector_uuid: $($BOSH_CLI status --uuid)" > cf-manifest/outputs/director-uuid.yml
 
   # Generate the manifest
-  CF_RELEASE_PATH=~/cf-release/ ./generate_deployment_manifest.sh $TARGET_PLATFORM > ~/cf-manifest.yml
+  ./cf-manifest/build_manifest.sh > ~/cf-manifest.yml
 }
 
 cf_deploy() {
@@ -48,20 +48,5 @@ cf_deploy() {
   time $BOSH_CLI -n deploy
 }
 
-cf_post_deploy() {
-  # Deploy psql broker
-  time bash $SCRIPT_DIR/deploy_psql_broker.sh \
-    admin $(get_cf_secret secrets/uaa_admin_password) \
-    admin $(get_cf_secret secrets/postgres_password)
-  # Deploy graphite nozzle
-  time bash $SCRIPT_DIR/deploy_graphite_nozzle.sh \
-    admin $(get_cf_secret secrets/uaa_admin_password) \
-    graphite-nozzle $(get_cf_secret secrets/uaa_clients_firehose_password)
-  # Deploy grafana dashboards
-  time bash $SCRIPT_DIR/deploy_grafana_dashboards.sh \
-    $terraform_output_grafana_dns_name
-}
-
 cf_compile_manifest
 cf_deploy
-cf_post_deploy

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash 
 
 set -e # fail on error
 
@@ -6,17 +6,9 @@ SCRIPT_DIR=$(cd $(dirname $0) && pwd)
 
 get_bosh_secret() { ${SCRIPT_DIR}/val_from_yaml.rb templates/bosh-secrets.yml $1; }
 
+STEMCELL=light-bosh-stemcell-3104-aws-xen-hvm-ubuntu-trusty-go_agent.tgz
 TARGET_PLATFORM=$1
-case $TARGET_PLATFORM in
-  aws)
-    ;;
-  gce)
-    ;;
-  *)
-    echo "Must specify the target platform: gce|aws"
-    exit 1
-    ;;
-esac
+TARGET_PLATFORM="aws"
 
 # Include the terraform output variables
 . $SCRIPT_DIR/terraform-outputs-${TARGET_PLATFORM}.sh
@@ -25,9 +17,17 @@ BOSH_ADMIN_USER=${BOSH_ADMIN_USER:-admin}
 BOSH_IP=${BOSH_IP:-$terraform_output_bosh_ip}
 BOSH_PORT=${BOSH_PORT:-25555}
 
+# Git cf-release to clone
+CF_RELEASE=225
+# Releases to upload
+BOSH_RELEASES="
+cf,$CF_RELEASE,https://bosh.io/d/github.com/cloudfoundry/cf-release?v=$CF_RELEASE
+"
 # Dependencies versions
 BOSH_INIT_VERSION=0.0.72
 BOSH_INIT_URL=https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-${BOSH_INIT_VERSION}-linux-amd64
+SPRUCE_VERSION=v0.13.0
+SPRUCE_URL=https://github.com/geofffranks/spruce/releases/download/${SPRUCE_VERSION}/spruce_0.13.0_linux_amd64.tar.gz
 SPIFF_VERSION=v1.0.7
 SPIFF_URL=https://github.com/cloudfoundry-incubator/spiff/releases/download/${SPIFF_VERSION}/spiff_linux_amd64.zip
 BOSH_CLI_VERSION=1.3056.0
@@ -73,11 +73,21 @@ install_dependencies() {
   echo "Installing gem packages..."
   bundle install --quiet
 
-  echo "Installing binaries: bosh-init, spiff, cf..."
+  echo "Installing binaries: bosh-init"
   if [ ! -x /usr/local/bin/bosh-init ]; then
     sudo wget -q $BOSH_INIT_URL -O /usr/local/bin/bosh-init
     sudo chmod +x /usr/local/bin/bosh-init
   fi
+
+  echo "Installing binaries: spruce"
+  if [ ! -x /usr/local/bin/spruce ]; then
+    wget -q $SPRUCE_URL -O spruce_linux_amd64.tar.gz
+    sudo tar -xf spruce_linux_amd64.tar.gz -C /usr/local/bin/ --strip-components=1
+    sudo chmod +x /usr/local/bin/spruce
+    rm spruce_linux_amd64.tar.gz
+  fi
+
+echo "Installing binaries: spiff"
 
   if [ ! -x /usr/local/bin/spiff ]; then
     wget -q $SPIFF_URL -O spiff_linux_amd64.zip
@@ -98,6 +108,7 @@ bosh_login() {
 }
 
 bosh_check_and_login() {
+  echo "Checking BOSH connection on $BOSH_IP:$BOSH_PORT"
   # Try to connect to the TCP port with 5s timeout
   nc -z -w 5 $BOSH_IP $BOSH_PORT || return 1
 
@@ -125,5 +136,61 @@ deploy_and_login_bosh() {
   fi
 }
 
+upload_stemcell() {
+  # Download the stemcell if it is not locally
+  cd ~
+  if [ ! -f $STEMCELL ]; then
+    echo "Downloading stemcell $STEMCELL"
+    if [ "$STEMCELL_URL" ]; then
+      wget $STEMCELL_URL
+    else
+      time $BOSH_CLI download public stemcell $STEMCELL
+    fi
+  fi
+
+  # Extract stemcell version and name info
+  mkdir -p /tmp/{$STEMCELL}.d
+  tar -xzf $STEMCELL -C /tmp/{$STEMCELL}.d stemcell.MF
+  stemcell_name=$(cat /tmp/{$STEMCELL}.d/stemcell.MF | awk '/^name:/ { print $2 }')
+  stemcell_version=$(cat /tmp/{$STEMCELL}.d/stemcell.MF | awk '/^version:/ { print $2 }' | tr -d "'")
+
+  # Upload stemcell if it is not uploaded
+  if bundle exec $SCRIPT_DIR/bosh_list_stemcells.rb | grep -q -e "$stemcell_name/$stemcell_version"; then
+    echo "Stemcell $stemcell_name/$stemcell_version already uploaded, skipping"
+  else
+    time $BOSH_CLI upload stemcell $STEMCELL --skip-if-exists
+  fi
+}
+
+upload_releases() {
+  for r in $BOSH_RELEASES; do
+    local name=$(echo $r | cut -f 1 -d ,)
+    local version=$(echo $r | cut -f 2 -d ,)
+    local url=$(echo $r | cut -f 3 -d ,)
+    local action=$(echo $r | cut -f 4 -d ,)
+    local directory=$(echo $r | awk -F"/" '{print $NF}' | cut -d"." -f 1)
+
+    if bundle exec $SCRIPT_DIR/bosh_list_releases.rb | grep -q "$name/$version"; then
+      echo "Release $name version $version already uploaded, skipping"
+      continue
+    else
+      if [[ ${action} == "create" ]] ; then
+         git_clone ${url} ${version}
+         if [[ $(grep -R ${version} ~/${directory}/dev_releases/) == "" ]]; then
+           $BOSH_CLI create release --name ${name} --version ${version}
+         fi
+         url=""
+      fi
+
+      $BOSH_CLI upload release $url 2>&1 | tee /tmp/upload_release.log
+      if [ $PIPESTATUS != 0 ] && ! grep -q -e 'Release.*already exists' /tmp/upload_release.log;  then
+        return 1
+      fi
+    fi
+  done
+}
+
 install_dependencies
 deploy_and_login_bosh
+upload_stemcell
+upload_releases


### PR DESCRIPTION
# What

Run the CF deployment using the new manifests in the Alpha pipeline.
Please note that this PR is against [vanilla_cf_prototype](https://github.com/alphagov/cf-terraform/tree/vanilla_cf_prototype) branch
# Details
- Makefile changes to call CF deployment scripts
- changes to provision.sh to install spruce on bastion host and upload
  CF releases
- generate cf manifest script that uses spruce to merge stubs and
  terraform outputs
- deploy CF script
- modified network config to fit our environment 
- RDS replaced with local postgres
- nginx as a SSL terminator
# How to test

```
make aws DEPLOY_ENV=name
```
# Who can test

anyone but @combor and @mtekel 
# Known issues
- logs don't work - we didn't investigate further
- some access issue with s3 bucket uploads (buckets are empty) so deployment doesn't work 
