### PR TITLE
[#11428952] Remove DEA/HM9000 infrastructure

### DIFF
--- a/cf-manifest/deployments/020-cf-resource-pools.yml
+++ b/cf-manifest/deployments/020-cf-resource-pools.yml
@@ -29,16 +29,6 @@ resource_pools:
     stemcell: (( grab meta.stemcell ))
     env: (( grab meta.default_env ))
 
-  - name: runner_z1
-    network: cf1
-    stemcell: (( grab meta.stemcell ))
-    env: (( grab meta.default_env ))
-
-  - name: runner_z2
-    network: cf2
-    stemcell: (( grab meta.stemcell ))
-    env: (( grab meta.default_env ))
-
   - name: router_z1
     network: "cf1"
     stemcell: (( grab meta.stemcell ))

--- a/cf-manifest/deployments/030-cf-jobs.yml
+++ b/cf-manifest/deployments/030-cf-jobs.yml
@@ -85,22 +85,6 @@ meta:
   - name: consul_agent
     release: (( grab meta.consul_templates.consul_agent.release ))
 
-  hm9000_routes:
-  - name: hm9000
-    port: 5155
-    tags:
-      component: HM9K
-    uris:
-    - (( concat "hm9000." properties.domain ))
-
-  hm9000_templates:
-  - name: hm9000
-    release: (( grab meta.release.name ))
-  - name: metron_agent
-    release: (( grab meta.release.name ))
-  - name: route_registrar
-    release: (( grab meta.release.name ))
-
   nats_templates:
   - name: nats
     release: (( grab meta.release.name ))
@@ -419,62 +403,6 @@ jobs:
         zone: z2
       nfs_server: (( grab meta.nfs_server ))
     update: {}
-
-  - name: hm9000_z1
-    templates: (( grab meta.hm9000_templates ))
-    instances: 1
-    resource_pool: medium_z1
-    networks:
-      - name: cf1
-    properties:
-      metron_agent:
-        zone: z1
-      route_registrar:
-        routes: (( grab meta.hm9000_routes ))
-    update: {}
-
-  - name: hm9000_z2
-    templates: (( grab meta.hm9000_templates ))
-    instances: 1
-    resource_pool: medium_z2
-    networks:
-      - name: cf2
-    properties:
-      metron_agent:
-        zone: z2
-      route_registrar:
-        routes: (( grab meta.hm9000_routes ))
-    update: {}
-
-  - name: runner_z1
-    templates: (( grab meta.dea_templates ))
-    instances: 1
-    resource_pool: runner_z1
-    networks:
-      - name: cf1
-        static_ips: ~
-    properties:
-      dea_next:
-        zone: "z1"
-      metron_agent:
-        zone: z1
-    update:
-      max_in_flight: 1
-
-  - name: runner_z2
-    templates: (( grab meta.dea_templates ))
-    instances: 1
-    resource_pool: runner_z2
-    networks:
-      - name: cf2
-        static_ips: ~
-    properties:
-      dea_next:
-        zone: "z2"
-      metron_agent:
-        zone: z2
-    update:
-      max_in_flight: 1
 
   - name: loggregator_z1
     templates: (( grab lamb_meta.loggregator_templates ))

--- a/cf-manifest/deployments/040-cf-properties.yml
+++ b/cf-manifest/deployments/040-cf-properties.yml
@@ -61,7 +61,7 @@ properties:
     audit_events:
       cutoff_age_in_days: 31
 
-    users_can_select_backend: true
+    users_can_select_backend: false
     default_to_diego_backend: true
     allow_app_ssh_access: true
     default_app_memory: 1024
@@ -169,9 +169,6 @@ properties:
         restart_if_consistently_above_mb: ~
         restart_if_above_mb: ~
     external_protocol: ~
-
-  hm9000:
-    url: (( concat "https://hm9000." properties.domain ))
 
   login:
     enabled: true

--- a/cf-manifest/deployments/aws/000-cf-infrastructure.yml
+++ b/cf-manifest/deployments/aws/000-cf-infrastructure.yml
@@ -102,22 +102,6 @@ resource_pools:
         type: gp2
       availability_zone: (( grab meta.zones.z2 ))
 
-  - name: runner_z1
-    cloud_properties:
-      instance_type: m3.large
-      ephemeral_disk:
-        size: 102_400
-        type: gp2
-      availability_zone: (( grab meta.zones.z1 ))
-
-  - name: runner_z2
-    cloud_properties:
-      instance_type: m3.large
-      ephemeral_disk:
-        size: 102_400
-        type: gp2
-      availability_zone: (( grab meta.zones.z2 ))
-
   - name: router_z1
     cloud_properties:
       instance_type: c3.large


### PR DESCRIPTION
**Note:** This is against `vanilla_cf_prototype` not master. We're PR'ing it here so the commits can be tested as the new manifests repo is not yet deployable. Once this is merged these commits need extracting and reapplying to the new manifests repository.

**Note 2:** The [previous PR](https://github.com/alphagov/cf-terraform/pull/110) to enable Diego _must_ be reviewed & merged before this PR.

This PR removes all the remaining DEA/HM9000 infrastructure now Diego is deployed in the new manifests. This also disables changing the diego boolean on deployed applications, as allowing users to do so when no DEA's are available causes the application to become unavailable.
## How to test this PR

`make aws DEPLOY_ENV=iamtestingdiego`, then try deploying an application to the CF instance using `cf-push` - spring music is a good example.

When deploying the application you will notice that the buildpack installation process is different and starts with "Creating container", then waffles about downloading buildpacks for a while:

```
Starting app spring-music in org GDS / space jim as admin...
Creating container
Successfully created container
Downloading app package...
Downloaded app package (21.1M)
No buildpack specified; fetching standard buildpacks to detect and build your application.
Downloading buildpacks (staticfile_buildpack, java_buildpack, ruby_buildpack, nodejs_buildpack, go_buildpack, python_buildpack, php_buildpack, binary_buil
dpack)...
Downloading nodejs_buildpack...
```
### To test that users can no longer toggle diego on an application:
1. Create a normal user account on the CF instance and switch to it - do not use admin as it has special privileges (`cf create-user`, `cf logout`, `cf login`).
2. Install the [deigo-cli plugin](https://github.com/cloudfoundry-incubator/diego-cli-plugin) (This is not required for normal CF use, just for toggling diego).
3. Run `cf has-diego-enabled spring-music` (assuming you deployed spring music) and you should get a `true` response.
4. Run `cf disable-diego spring-music` and you should get..

```
FAILED
Error:  CF-BackendSelectionNotAuthorized - You cannot select the backend on which to run this application
{
   "code": 320005,
   "description": "You cannot select the backend on which to run this application",
   "error_code": "CF-BackendSelectionNotAuthorized"
}
```
## Who can review this PR

Anybody but @jimconner and @jonty, who still disliked this less than concourse.
