### PR TITLE
[#115700473] Fix issues in logsearch filters and mappings

### DIFF
--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -385,6 +385,14 @@ properties:
                             "enabled" : false
                         },
                         "index" : "not_analyzed"
+                      },
+                      "log_level" : {
+                        "index" : "not_analyzed",
+                        "type" : "string"
+                      },
+                      "timestamp" : {
+                        "index" : "not_analyzed",
+                        "type" : "string"
                       }
                   },
                   "dynamic_templates" : [

--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -310,100 +310,100 @@ properties:
     templates:
       - logsearch-for-cloudfoundry: |
           {
-              "template" : "logstash-*",
-              "order" : 50,
-              "settings" : {
-              "number_of_shards" : 5,
-              "number_of_replicas" : 0,
-              "index" : {
-                      "search" : {
-                  "slowlog" : {
-                              "threshold" : {
-                      "query" : {
-                                      "warn" : "15s",
-                                      "info" : "10s",
-                                      "debug" : "5s",
-                                      "trace" : "500ms"
+            "template" : "logstash-*",
+            "settings" : {
+                "number_of_replicas" : 0,
+                "number_of_shards" : 5,
+                "index" : {
+                  "store" : {
+                      "compress" : {
+                        "stored" : true,
+                        "tv" : true
                       }
-                              }
-                  }
-                      },
-                      "query" : {
-                  "default_field" : "@message"
-                      },
-                      "store" : {
-                  "compress" : {
-                              "stored" : true,
-                              "tv": true
-                  }
-                      }
-              }
-              },
-              "mappings": {
-              "_default_": {
-                      "_all": {
-                  "enabled": false
-                      },
-                      "_source": {
-                  "compress": true
-                      },
-                      "dynamic_templates": [
-                  {
-                              "string_template" : {
-                      "match" : "*",
-                      "mapping": {
-                                      "type": "string",
-                                      "index": "not_analyzed",
-                                      "norms" : {
-                          "enabled" : false
-                                      }
-                      },
-                      "match_mapping_type" : "string"
-                              }
-                  }
-                      ],
-                      "properties" : {
-                  "@message" : {
-                              "type" : "string",
-                              "index" : "analyzed",
-                              "norms" : {
-                      "enabled" : false
-                              }
                   },
-                  "@tags": {
-                              "type": "string",
+                  "query" : {
+                      "default_field" : "@message"
+                  },
+                  "search" : {
+                      "slowlog" : {
+                        "threshold" : {
+                            "query" : {
+                              "trace" : "500ms",
+                              "debug" : "5s",
+                              "info" : "10s",
+                              "warn" : "15s"
+                            }
+                        }
+                      }
+                  }
+                }
+            },
+            "mappings" : {
+                "_default_" : {
+                  "_source" : {
+                      "compress" : true
+                  },
+                  "_all" : {
+                      "enabled" : false
+                  },
+                  "properties" : {
+                      "message" : {
+                        "type" : "string",
+                        "norms" : {
+                            "enabled" : false
+                        },
+                        "index" : "analyzed"
+                      },
+                      "@tags" : {
+                        "type" : "string",
+                        "norms" : {
+                            "enabled" : false
+                        },
+                        "index" : "not_analyzed"
+                      },
+                      "geoip" : {
+                        "properties" : {
+                            "location" : {
+                              "type" : "geo_point"
+                            }
+                        }
+                      },
+                      "@timestamp" : {
+                        "index" : "not_analyzed",
+                        "type" : "date"
+                      },
+                      "@message" : {
+                        "index" : "analyzed",
+                        "type" : "string",
+                        "norms" : {
+                            "enabled" : false
+                        }
+                      },
+                      "@type" : {
+                        "type" : "string",
+                        "norms" : {
+                            "enabled" : false
+                        },
+                        "index" : "not_analyzed"
+                      }
+                  },
+                  "dynamic_templates" : [
+                      {
+                        "string_template" : {
+                            "mapping" : {
                               "index" : "not_analyzed",
                               "norms" : {
-                      "enabled" : false
-                              }
-                  },
-                  "@timestamp" : {
-                              "type" : "date",
-                              "index" : "not_analyzed"
-                  },
-                  "@type" : {
-                              "type" : "string",
-                              "index" : "not_analyzed",
-                              "norms" : {
-                      "enabled" : false
-                              }
-                  },
-                  "message" : {
-                              "type" : "string",
-                              "index" : "analyzed",
-                              "norms" : {
-                      "enabled" : false
-                              }
-                  },
-                  "geoip" : {
-                              "properties" : {
-                      "location" : {
-                          "type" : "geo_point"
+                                  "enabled" : false
+                              },
+                              "type" : "string"
+                            },
+                            "match" : "*",
+                            "match_mapping_type" : "string"
+                        }
                       }
-                      }
-                  }
-                      }
-              }
-              }
+                  ]
+                }
+            },
+            "order" : 50
           }
 

--- a/manifests/templates/logsearch/logsearch-filters.yml
+++ b/manifests/templates/logsearch/logsearch-filters.yml
@@ -305,6 +305,16 @@ properties:
           remove_field => [ "data" ]
         }
       }
+      # Short term fix (aka definitive solution), drop the data field to avoid
+      # error inserting in ES.
+      # If not, it will insert new fields with the app name, resulting in thousands
+      # of fields in the index, which breaks kibana
+      if [@shipper.name] == "vcap_cloud_controller_ng_relp" {
+        mutate {
+          remove_field => [ "data" ]
+        }
+      }
+
 
   elasticsearch_config:
     templates:


### PR DESCRIPTION
## What

We have experienced some issues with our logsearch setup due some spurious messages:
- Invalid type mapping of `log_level` field after log rotation
- Creation of fields with the app name which saturates kibana.
## Scope

We want to do a short term fix for these two problems, so that:
1. We force the type of `log_level` setting up the type in the index template.
2. We drop the data that creates the fields with the app name.

In beta we will find a long term solution
## How to test this

As we don't want to waste too much time, we consider that is OK to validate the PR and
merge without testing. Trial should deploy anyway.

To test each feature, ssh to the logsearch:

```
make ssh-aws DEPLOY_ENV=trial
```

Test the type of log_level

```
curl -XPUT http://127.0.0.1:9200/logstash-test/
cat <<EOF | curl -X POST -d@- "DELETE "http://localhost:9200/logstash-test/relp_cf/"
{
  "@version":"1","@timestamp":"2016-03-18T00:01:45.812Z","_logstash_input":"relp","host":"10.0.10.41:50339","@type":"relp_cf","@message":"<13>2016-03-18T00:01:45.812385+00:00 10.0.10.41 vcap.routing-api [job=api_z1 index=0]  {\"timestamp\":\"1458259305.812311411\",\"source\":\"routing-api\",\"message\":\"routing-api.request.done\",\"log_level\":1,\"data\":{\"method\":\"GET\",\"request\":\"/v1/routes\",\"response-headers\":{\"X-Cf-Requestid\":[\"16c55fc5-023b-410e-7f5a-541ef135b1e6\"]},\"session\":\"16531\"}}","syslog_pri":"13","received_at":"2016-03-18T00:01:45.811Z","received_from":"10.0.10.41:50339","tags":["syslog_standard","cloudfoundry_vcap"],"@source.host":"10.0.10.41","@job.name":"api_z1","@job.index":"0","timestamp":"1458259305.812311411","source":"routing-api","message":"routing-api.request.done","log_level":1,"@shipper.name":"vcap_routing-api_relp","@job.host":"10.0.10.41","@shipper.priority":"13",
    "log_level": 1
    }
EOF


curl -XGET 'http://localhost:9200/logstash-test/_mapping/relp_cf?pretty=true'  | less

curl -XDELETE 'http://localhost:9200/logstash-test/_mapping/relp_cf?pretty=true'

```

Test the drop of the data message:

```
cat <<EOF | curl -X POST -d@- "http://localhost:9200/logstash-$(date +%Y.%m.%d)/relp_cf/"
{
   "lineno" : 103,
   "fiber_id" : 70010513636780,
   "file" : "/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/lib/cloud_controller/dea/hm9000/client.rb",
   "source" : "cc.healthmanager.client",
   "message" : "received bulk_app_state response",
   "log_level" : "info",
   "data" : {
      "message" : [
         {
            "droplet" : "8ff21266-4444-427e-8c42-db8b630479b2",
            "version" : "40f131cd-5548-4b0f-865e-486a88796428"
         }
      ],
      "request_guid" : "f9530b4f-2b2e-4ee6-7191-aace60034cbc::d98cffb3-5295-4ad4-bb2b-37fce9c41dc8",
      "responses" : {
         "8ff21266-4444-427e-8c42-db8b630479b2" : {
            "droplet" : "8ff21266-4444-427e-8c42-db8b630479b2",
            "desired" : {
               "version" : "",
               "package_state" : "",
               "state" : "",
               "instances" : 0,
               "id" : ""
            },
            "version" : "40f131cd-5548-4b0f-865e-486a88796428",
            "instance_heartbeats" : [
               {
                  "state_timestamp" : 1458214758,
                  "index" : 0,
                  "version" : "40f131cd-5548-4b0f-865e-486a88796428",
                  "dea_guid" : "0-1d886652c9674691b81071dbabcdd153",
                  "droplet" : "8ff21266-4444-427e-8c42-db8b630479b2",
                  "state" : "RUNNING",
                  "instance" : "51a12e90b03d4b0eaddc0abaa326dd69"
               },
               {
                  "version" : "40f131cd-5548-4b0f-865e-486a88796428",
                  "index" : 1,
                  "state_timestamp" : 1458214768.4,
                  "state" : "RUNNING",
                  "instance" : "f46f703b54e24652bfee5fa790ec0f31",
                  "dea_guid" : "0-05c2393aeedf48e693ba12281bb0c11d",
                  "droplet" : "8ff21266-4444-427e-8c42-db8b630479b2"
               }
            ],
            "crash_counts" : []
         }
      }
   },
   "method" : "make_request",
   "timestamp" : 1458214770.0371,
   "process_id" : 15149,
   "thread_id" : 70010513410440,
   "random_id" : "54d801ca-d9e3-43d7-939e-af7dade46340"
}
EOF

sleep 2

curl -XGET "http://localhost:9200/logstash-$(date +%Y.%m.%d)/_search?q=random_id:54d801ca-d9e3-43d7-939e-af7dade46340&from=0&size=1&fields=data,_source&pretty=true"

```
## who?

Anyone but @keymon
