### PR TITLE
[#108439336] Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# DEPRECATED
+
+This repository is no longer maintained. It was used for an alpha project by
+the Government PaaS team. You can follow what we're doing now at
+[alphagov/paas-cf](https://github.com/alphagov/paas-cf).
+
 #CloudFoundry Terraform
 
 To provision a microbosh instance on AWS and GCE.


### PR DESCRIPTION
## What

When merged I will prefix the name of this repo with `paas-alpha-` and
transfer ownership to https://github.com/gds-attic

GitHub will redirect requests for the old name(s) to the new location.
## How to review

Check that the README change makes sense.
## Who can review

Not @dcarley
